### PR TITLE
Update requirements.txt to include tqdm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://git@github.com/ndustrialio/ndustrialio-python.git@SPIKE/assetsII#egg=ndustrialio-python
 tabulate
 dateutils
+tqdm


### PR DESCRIPTION
Missing package when trying to run the cli

Before:
`Brets-MBP:contxt-sdk-python baskeland$ python3 main.py
Traceback (most recent call last):
  File "main.py", line 5, in <module>
    from contxt.cli.ems import EMS
  File "/Users/baskeland/github/python-sdk/contxt-sdk-python/contxt/cli/ems.py", line 2, in <module>
    from tqdm import tqdm
ModuleNotFoundError: No module named 'tqdm'`

After:
`Brets-MBP:contxt-sdk-python baskeland$ python3 main.py -h
Token file has not been created yet
2019-02-19 10:18:50,658 INFO     [contxt.utils.auth]  Token doesn't exist or can't be refreshed. Please re-authenticate (auth.py:121) `