### PR TITLE
Fix iot feeds call and auth0 import name

### DIFF
--- a/contxt/cli/parsers.py
+++ b/contxt/cli/parsers.py
@@ -98,7 +98,7 @@ class IotParser(ArgParser):
     def _feeds(self, args, auth):
         from contxt.functions.iot import IOT
         iot = IOT(auth)
-        feeds = iot.iot_service.get_all_feeds(args.facility_id)
+        feeds = iot.iot_service.get_feeds_collection(args.facility_id)
         print(feeds)
 
     def _fields(self, args, auth):

--- a/contxt/utils/auth.py
+++ b/contxt/utils/auth.py
@@ -4,8 +4,7 @@ from getpass import getpass
 from pathlib import Path
 
 import jwt
-from auth0.v3.authentication.get_token import GetToken
-
+from auth0.v3.authentication import GetToken
 from contxt.services.auth import ContxtAuthService
 from contxt.utils import Config, Utils, make_logger
 


### PR DESCRIPTION
**Why**
IoT feeds call was not calling the correct IOTService underlying function since the refactor.
Auth0-python since we are using v3 now the import namespace needed to be changed for GetToken.

***Test***
```
(venv) baskeland@Brets-MBP-2 contxt-sdk-python (master) $ contxt iot feeds -f 191
  id    feed_type_id  down_after    key               facility_id  timezone                           token                             status      degraded_threshold    critical_threshold  status_event_id                       created_at
----  --------------  ------------  --------------  -------------  ---------------------------------  --------------------------------  --------  --------------------  --------------------  ------------------------------------  ------------------------
1127               6                123-ngest-demo            191  Eastern Standard Time (UTC -4:00)  c9cb05664edd17bfe67b97c6313a9eed  Active                     0.8                   0.2  7dd32a32-ce2e-430f-a299-f6cc21971362  2019-03-19T19:06:34.820Z
```
```
(venv) baskeland@Brets-MBP-2 contxt-sdk-python (master) $ contxt iot groupings 191
id                                    label          slug           description      facility_id  field_category_id    field_category_name      field_count
------------------------------------  -------------  -------------  -------------  -------------  -------------------  ---------------------  -------------
eadafde1-9df5-439c-904d-96dd9446216b  Test Grouping  test-grouping  Test                     191                                                          1
```