### PR TITLE
Make organization name case insensitive for users lookup

### DIFF
--- a/contxt/functions/organizations.py
+++ b/contxt/functions/organizations.py
@@ -8,6 +8,7 @@ def find_organization_by_name(contxt_service, organization_name):
     for org in contxt_service.get_organizations():
         if org.name.upper() == organization_name.upper():
             organization = org
+            break
 
     return organization
 


### PR DESCRIPTION
***Why***
When testing out the users CLI method I noticed the org name is case sensitive for the lookup.  There isn't a reason to restrict case to hinder the user's experience.

***Test***
```
>>> t = 'artis energy'
>>> tt = 'Artis Energy'
>>> t == tt
False
>>> t.upper() == tt.upper()
True
```
```
(venv) baskeland@Brets-MBP-2 contxt-sdk-python (master) $ contxt contxt users -n 'Artis energy'
id                              first_name    last_name    is_activated    roles
------------------------------  ------------  -----------  --------------  ----------
auth0|5c5336ed2313fa3598ea425a  Bret          Askeland     True            user,admin
```