### PR TITLE
Update iot.py to remove old DataResponse wrapper for get_field_descriptors

### DIFF
--- a/contxt/services/iot.py
+++ b/contxt/services/iot.py
@@ -113,12 +113,7 @@ class IOTService(Service):
 
         params = {"limit": limit, "offset": offset}
 
-        return DataResponse(
-            data=self.execute(
-                GET(uri=f"feeds/{feed_id}/fields").params(params), execute=True
-            ),
-            client=self.client,
-        )
+        return self.execute(GET(uri=f"feeds/{feed_id}/fields").params(params), execute=True)
 
     def get_feeds_collection(self, facility_id=None, key=None):
         assert isinstance(facility_id, (type(None), int))


### PR DESCRIPTION
***WHY***
The payload for get_field_descriptors does not have the object structure yet to conform to DataResponse object wrapper.