### PR TITLE
CTOOLS-16: New Auth classes

### DIFF
--- a/contxt/__main__.py
+++ b/contxt/__main__.py
@@ -35,9 +35,9 @@ def main():
 
     # Launch the command
     if "func" in args:
-        from contxt.auth.cli import CLIAuth
+        from contxt.auth.cli import CliAuth
 
-        auth = CLIAuth()
+        auth = CliAuth()
         args.func(args, auth)
 
 

--- a/contxt/auth/__init__.py
+++ b/contxt/auth/__init__.py
@@ -27,10 +27,13 @@ class TokenProvider:
         self._access_token_decoded: Optional[Dict] = None
 
     def _token_expiring(self, within: int = 60) -> bool:
-        """Returns if `access_token` is within `within` seconds of expiring"""
-        return self.decoded_access_token["exp"] <= (
-            datetime.now(UTC).timestamp() + within
-        )
+        """Returns if `access_token` is within `within` seconds of expiring.
+        Returns `False` if `exp` is not in the token's claims."""
+        expiration = self.decoded_access_token.get("exp")
+        if not expiration:
+            logger.debug("'exp' not in token's claims")
+            return False
+        return expiration <= datetime.now(UTC).timestamp() + within
 
     @property
     def access_token(self) -> str:

--- a/contxt/auth/__init__.py
+++ b/contxt/auth/__init__.py
@@ -1,142 +1,74 @@
 from datetime import datetime
-from json import dump, load
-from pathlib import Path
+from typing import Dict, Optional
 
-from auth0.v3.authentication import GetToken
 from jwt import decode
+from pytz import UTC
 
-from contxt.services.auth import ContxtAuthService
-from contxt.utils import Utils, make_logger
+from contxt.services.auth import AuthService
+from contxt.utils import make_logger
 
 logger = make_logger(__name__)
 
-AUTH_AUDIENCE = '75wT048QcpE7ujwBJPPjr263eTHl4gEX'
+
+class TokenProvider:
+    """
+    Provides an unexpired `access_token` from the source client (defined by
+    `client_id` and `client_secret`) for the target client (defined by `audience`).
+
+    Overload this class to customize how the `access_token` is fetched and refreshed.
+    """
+
+    def __init__(self, client_id: str, client_secret: str, audience: str):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.audience = audience
+        self.auth_service = AuthService()
+        self._access_token: Optional[str] = None
+        self._access_token_decoded: Optional[Dict] = None
+
+    def _token_expiring(self, within: int = 60) -> bool:
+        """Returns if `access_token` is within `within` seconds of expiring"""
+        return self.decoded_access_token["exp"] <= (
+            datetime.now(UTC).timestamp() + within
+        )
+
+    @property
+    def access_token(self) -> str:
+        """Gets a valid access_token for audience `audience`"""
+        if self._access_token is None or self._token_expiring():
+            # Token either not set or expiring soon, fetch one
+            self.access_token = self.auth_service.get_oauth_token(
+                self.client_id, self.client_secret, self.audience
+            )
+        return self._access_token
+
+    @access_token.setter
+    def access_token(self, value: str) -> None:
+        """Sets both the `access_token` and the `decoded_access_token`"""
+        self._access_token = value
+        self._access_token_decoded = decode(self._access_token, verify=False)
+
+    @property
+    def decoded_access_token(self) -> Dict:
+        """Gets the `decoded_access_token`"""
+        if self._access_token_decoded is None:
+            # Token not yet set, fetch it now
+            self.access_token
+        return self._access_token_decoded
 
 
 class BaseAuth:
+    """
+    A client (service, worker, etc.) defined by `client_id` and `client_secret`.
+    When the client needs to authenicate to another client, use `get_token_provider`.
 
-    def __init__(self, client_id, client_secret=None, cli_mode=False):
+    Overload this class to return a custom `TokenProvider`.
+    """
+
+    def __init__(self, client_id: str, client_secret: str):
         self.client_id = client_id
         self.client_secret = client_secret
-        self.auth0 = GetToken('ndustrial.auth0.com')
 
-        self.contxt_config_path = Path.home() / '.contxt'
-        self.token_file = self.contxt_config_path / 'tokens'
-
-        # load up the tokens we have
-        self.tokens = self.load_tokens()
-
-        self.auth_access_token = self.get_token_for_audience(
-            AUTH_AUDIENCE) if AUTH_AUDIENCE in self.tokens else None
-
-        if not cli_mode:
-            self.contxt_auth = ContxtAuthService(access_token=self.auth_access_token,
-                                                 client_id=self.client_id,
-                                                 client_secret=self.client_secret)
-        else:
-            # if there is no token for auth, then we need to go ask the user to login so we can get one
-            if not self.auth_access_token:
-                self.login()
-                self.auth_access_token = self.get_token_for_audience(
-                    AUTH_AUDIENCE) if AUTH_AUDIENCE in self.tokens else None
-
-            self.contxt_auth = ContxtAuthService(access_token=self.auth_access_token)
-
-    def get_auth_token(self):
-        return self.auth_access_token
-
-    def set_auth_token(self, access_token, refresh_token=None):
-        self.auth_access_token = access_token
-        self.store_service_token(audience=AUTH_AUDIENCE,
-                                 access_token=access_token,
-                                 refresh_token=refresh_token)
-
-    def refresh_contxt_auth_token(self):
-        logger.debug(f"Refreshing contxt auth token")
-        refresh_token = self.tokens[AUTH_AUDIENCE]['refresh_token']
-        token = self.auth0.refresh_token(client_id=self.client_id,
-                                         client_secret=self.client_secret or '',
-                                         refresh_token=refresh_token)
-
-        # store the new access token and re-store the existing refresh token
-        self.store_service_token(audience=AUTH_AUDIENCE,
-                                 access_token=token['access_token'],
-                                 refresh_token=refresh_token)
-
-    def authenticate_to_service(self, service_audience):
-        logger.debug(f"Getting new token for {service_audience}")
-        token = self.contxt_auth.get_new_token_for_audience(service_audience)
-        self.store_service_token(audience=service_audience,
-                                 access_token=token)
-        return token
-
-    def get_token_for_audience(self, audience):
-        logger.debug(f"Getting token for client {audience}")
-        # check to see if we've gotten a token for this service or not
-        if audience not in self.tokens:
-            # try to get a token, whether it's a refresh or not
-            self.authenticate_to_service(audience)
-
-        # check to see if have the token, but needs to be refreshed
-        if self.token_is_expired_for_audience(audience):
-            logger.warn(f"Refreshing expired token for client {audience}...")
-
-            # if it's the contxt auth client, we need to follow the other refresh route via Auth0
-            if audience == AUTH_AUDIENCE:
-                self.refresh_contxt_auth_token()
-            else:
-                self.authenticate_to_service(audience)
-
-        access_token = self.tokens[audience]['token']
-        return access_token
-
-    def token_is_expired_for_audience(self, audience):
-        logger.debug(f"Checking if token is expired for audience {audience}")
-        if not self.tokens.get(audience):
-            return True
-        access_token = self.tokens[audience]['token']
-        decoded_token = decode(access_token, verify=False)
-        token_expiration_epoch = decoded_token['exp']
-
-        return token_expiration_epoch <= Utils.get_epoch_time(datetime.now())
-
-    def read_token_file(self):
-        logger.debug(f"Loading tokens from {self.token_file}")
-        self.contxt_config_path.mkdir(parents=True, exist_ok=True)
-
-        try:
-            with self.token_file.open('r') as f:
-                return load(f)
-        except FileNotFoundError:
-            logger.debug("Token file does not yet exist")
-            return {}
-
-    def load_tokens(self):
-        all_tokens = self.read_token_file()
-        return all_tokens.get(self.client_id, {})
-
-    def store_service_token(self, audience, access_token, refresh_token=None):
-
-        self.tokens.setdefault(self.client_id, {})
-        # if self.client_id not in self.tokens:
-        #     self.tokens[self.client_id] = {}
-
-        self.tokens[audience] = {
-            'token': access_token,
-            'refresh_token': refresh_token
-        }
-
-        self.store_tokens(self.tokens)
-
-    def store_tokens(self, tokens_for_client):
-        logger.debug(f"Storing tokens to {self.token_file}")
-
-        all_tokens = self.read_token_file()
-        all_tokens[self.client_id] = tokens_for_client
-
-        with self.token_file.open("w") as f:
-            dump(all_tokens, f, indent=4)
-
-    def clear_tokens(self):
-        logger.debug(f"Removing toke file {self.token_file}")
-        self.token_file.unlink()
+    def get_token_provider(self, audience: str) -> TokenProvider:
+        """Get `TokenProvider` for audience `audience`"""
+        return TokenProvider(self.client_id, self.client_secret, audience)

--- a/contxt/auth/__init__.py
+++ b/contxt/auth/__init__.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Dict, Optional
 
-from jwt import decode
+from jose.jwt import get_unverified_claims
 from pytz import UTC
 
 from contxt.services.auth import AuthService
@@ -47,7 +47,7 @@ class TokenProvider:
     def access_token(self, value: str) -> None:
         """Sets both the access token and the decoded access token"""
         self._access_token = value
-        self._access_token_decoded = decode(self._access_token, verify=False)
+        self._access_token_decoded = get_unverified_claims(self._access_token)
 
     @property
     def decoded_access_token(self) -> Dict:

--- a/contxt/auth/__init__.py
+++ b/contxt/auth/__init__.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Dict, Optional
 
@@ -93,18 +94,19 @@ class DependentTokenProvider(TokenProvider):
         return self._access_token
 
 
-class BaseAuth:
+class BaseAuth(ABC):
     """
-    A client (service, worker, etc.) defined by `client_id` and `client_secret`.
-    When the client needs to authenicate to another client, use `get_token_provider(...)`.
+    An abstract base class for a client (user, service, worker, etc.) defined
+    by `client_id` and `client_secret`. When the client needs to authenticate
+    to another client, use `get_token_provider(...)`.
 
-    Overload this class to return a custom `TokenProvider`.
+    Overload this class to implement `get_token_provider(...)`.
     """
 
     def __init__(self, client_id: str, client_secret: str):
         self.client_id = client_id
         self.client_secret = client_secret
 
+    @abstractmethod
     def get_token_provider(self, audience: str) -> TokenProvider:
         """Get `TokenProvider` for audience `audience`"""
-        return TokenProvider(self.client_id, self.client_secret, audience)

--- a/contxt/auth/cli.py
+++ b/contxt/auth/cli.py
@@ -168,9 +168,17 @@ class CliAuth(BaseAuth):
         """Get `TokenProvider` for audience `audience`"""
         return DependentTokenProvider(self.token_provider, audience)
 
+    def logged_in(self) -> bool:
+        return bool(self.token_provider._access_token)
+
     def login(self) -> None:
-        """Prompt the user to login"""
-        pass
+        """Force a prompt for the user to login. Note this will happen automatically."""
+        if self.logged_in() and not self.query_user("Already logged in. Continue?"):
+            return None
+        # NOTE: this works by unsetting the current access token, and then
+        # calling the getter, which triggers a login prompt 
+        self.token_provider.reset()
+        self.token_provider.access_token
 
     def logout(self) -> None:
         """Logs the user out by clearing the cache"""

--- a/contxt/auth/cli.py
+++ b/contxt/auth/cli.py
@@ -1,59 +1,172 @@
 from getpass import getpass
+from json import dump, load
+from pathlib import Path
+from typing import Dict, Optional
 
-from contxt.auth import BaseAuth
-from contxt.services.auth import ContxtAuthService
-from contxt.utils import Config, make_logger
+from auth0.v3.authentication import GetToken
 
-logger = make_logger(__name__)
+from contxt.auth import BaseAuth, DependentTokenProvider, TokenProvider
+from contxt.services.auth import AuthService
+from contxt.utils import make_logger
+
+logger = make_logger(__name__, "debug")
 
 
-class CLIAuth(BaseAuth):
+class Auth0TokenProvider(TokenProvider):
     """
-    Authentication for a CLI user
+    Same as `TokenProvider`, but the access token provided is authenticated via
+    username and password and granted for offline access, meaning expired tokens
+    are refreshed with a refresh token. To do so, our own Auth API
+    (i.e. `AuthService`) is replaced by Auth0's API.
     """
 
-    def __init__(self, force_login=True):
-        super().__init__(client_id=Config.CLI_CLIENT_ID, cli_mode=True)
+    def __init__(self, client_id: str, client_secret: str, audience: str):
+        super().__init__(client_id, client_secret, audience)
+        # Replace our auth api with auth0, and also store a refresh token
+        self.auth_service = GetToken("ndustrial.auth0.com")
+        self._refresh_token: Optional[str] = None
 
-        if self.get_auth_token() is None and force_login:
-            logger.info("Token doesn't exist or can't be refreshed. Please re-authenticate")
-            self.login()
+    def _get_new_access_token(self) -> str:
+        token = self.login()
+        self.refresh_token = token["refresh_token"]
+        return token["access_token"]
 
-    def _query_user(self, question):
-        accepted_answers = ["y", "n"]
-        ans = input(f"{question} ({'/'.join(accepted_answers)}) ").lower()[0:1]
-        while ans not in accepted_answers:
-            ans = input(
-                f"Please enter {' or '.join(accepted_answers)}. ").lower()[0:1]
-        return ans == "y"
+    def _refresh_access_token(self) -> str:
+        token = self.auth_service.refresh_token(
+            self.client_id, self.client_secret, self.refresh_token
+        )
+        self.refresh_token = token["refresh_token"]
+        return token["access_token"]
 
-    def login(self):
+    @property
+    def refresh_token(self) -> str:
+        """Gets the refresh token"""
+        if self._refresh_token is None:
+            # Token not yet set, fetch it now
+            self.access_token
+        return self._refresh_token
 
-        # Check login is needed
-        if self.get_auth_token() is not None:
-            if not self._query_user("Already logged in. Continue?"):
-                return
+    @refresh_token.setter
+    def refresh_token(self, value: str) -> None:
+        """Sets the refresh token"""
+        self._refresh_token = value
 
-        # Prompt for username/password
-        username = input("Contxt Username: ")
-        password = getpass("Contxt Password: ")
+    def login(
+        self, username: Optional[str] = None, password: Optional[str] = None
+    ) -> Dict:
+        """Returns an access_token from Auth0, from client `client_id` and
+        `client_secret` for audience `audience`, with username `username` and
+        password `password`"""
+        return self.auth_service.login(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            username=username or input("Contxt Username: "),
+            password=password or getpass("Contxt Password: "),
+            scope="offline_access",
+            audience=self.audience,
+            grant_type="password",
+            realm="",
+        )
 
-        # Login
-        token = self.auth0.login(
-            client_id=Config.CLI_CLIENT_ID,
-            client_secret=Config.CLI_CLIENT_SECRET,
-            username=username,
-            password=password,
-            scope='offline_access',
-            audience=Config.AUTH_AUDIENCE_ID,
-            grant_type='password',
-            realm='')
 
-        # Store token
-        self.store_service_token(
-            audience=Config.AUTH_AUDIENCE_ID,
-            access_token=token['access_token'],
-            refresh_token=token['refresh_token'])
+class CliAuth(BaseAuth):
+    """
+    Same as `BaseAuth`, but specifically for the client CLI. It uses
+    `Auth0TokenProvider` to authenticate requests to get an access token for
+    target clients defined by `audience`.
 
-    def reset(self):
-        self.clear_tokens()
+    If `enable_cache` is True, the access token from Auth0 will be cached in a
+    JSON file in a hidden directory, meaning that the user will only have to
+    authenticate with their credientials once.
+
+    Auth Flow:
+    1. User provides Contxt username/password credentials
+    2. Retrieve access token directly from Auth0 for our `AuthService`, authenticating with
+       above credientials
+    3. When authenticating to a service, retrieve access token from our `AuthService`
+       for the target service, authenticating with the above Auth0 access token
+    """
+
+    def __init__(self):
+        super().__init__(
+            client_id="bleED0RUwb7CJ9j7D48tqSiSZRZn29AV",
+            client_secret="0s8VNQ26QrteS3H5KXIIPvkDcNL5PfT-_pWwAVNI4MpDaDg86O2XUH8lT19KLNiZ",
+        )
+        self.auth_service = AuthService()
+        self.token_provider = Auth0TokenProvider(
+            self.client_id, self.client_secret, self.auth_service.config.audience
+        )
+
+        # Initialize cache details
+        self._cache_file = Path.home() / ".contxt_new" / "tokens_v2"
+        self._cache = {}
+        self._init_cache()
+
+    def get_token_provider(self, audience: str) -> DependentTokenProvider:
+        """Get `TokenProvider` for audience `audience`"""
+        return DependentTokenProvider(self.token_provider, audience)
+
+    def logged_in(self) -> bool:
+        return self.token_provider.audience in self._cache
+
+    def login(self) -> None:
+        """Prompt the user to login"""
+        pass
+        # # Ensure we are in a logged out state
+        # self.logout()
+        # # Trigger a login prompt and update the cache
+        # # NOTE: This works by fetching the access token
+        # self._init_cache()
+
+    def logout(self) -> None:
+        """Logs the user out by clearing the cache"""
+        # Clear the cached and current access_token
+        self.token_provider._access_token = None
+        self.clear_cache()
+
+    def query_user(self, question: str) -> bool:
+        """Query the user with `question`, and return if user confirmed"""
+        choices = ("y", "n")
+        # Get only the first character in the response
+        answer = input(f"{question} ({'/'.join(choices)}) ").lower()[0:1]
+        while answer not in choices:
+            answer = input(f"Please enter {' or '.join(choices)}. ").lower()[0:1]
+        return answer == "y"
+
+    def _init_cache(self):
+        # Load the cache
+        self._cache = self.read_cache()
+
+        # Only cache the auth0 access_token, so we do not have to repeatedly
+        # query the user for their credentials
+        if self.token_provider.audience in self._cache:
+            # Token exists in cache, set it
+            token_info = self._cache[self.token_provider.audience]
+            self.token_provider.access_token = token_info["access_token"]
+            self.token_provider.refresh_token = token_info["refresh_token"]
+        else:
+            # Token not in cache, update it
+            # NOTE: this triggers a login prompt
+            self._cache[self.token_provider.audience] = {
+                "access_token": self.token_provider.access_token,
+                "refresh_token": self.token_provider.refresh_token
+            }
+            self.update_cache()
+
+    def read_cache(self) -> Dict:
+        logger.debug(f"Reading tokens from {self._cache_file}")
+        if self._cache_file.is_file():
+            with self._cache_file.open("r") as f:
+                return load(f)
+        return {}
+
+    def update_cache(self) -> None:
+        logger.debug(f"Updating tokens from {self._cache_file}")
+        self._cache_file.parent.mkdir(parents=True, exist_ok=True)
+        with self._cache_file.open("w") as f:
+            dump(self._cache, f, indent=4)
+
+    def clear_cache(self) -> None:
+        logger.debug(f"Clearing tokens from {self._cache_file}")
+        self._cache_file.unlink()
+        self._cache = {}

--- a/contxt/auth/cli.py
+++ b/contxt/auth/cli.py
@@ -163,7 +163,7 @@ class UserTokenProvider(TokenProvider):
 class CliAuth(Auth):
     """
     Same as `Auth`, but specifically for the client CLI. It uses
-    `UserTokenProvider` to authenticate requests to get an access token for
+    `UserIdentityProvider` to authenticate requests to get an access token for
     target clients defined by `audience`.
 
     The access token from Auth0 is cached in a JSON file in a hidden directory,

--- a/contxt/auth/cli.py
+++ b/contxt/auth/cli.py
@@ -105,7 +105,7 @@ class Auth0TokenProvider(TokenProvider):
             grant_type="password",
             realm="",
         )
-    
+
     def reset(self):
         super().reset()
         self._refresh_token: Optional[str] = None

--- a/contxt/auth/machine.py
+++ b/contxt/auth/machine.py
@@ -1,14 +1,39 @@
-from contxt.auth import BaseAuth, TokenProvider
+from contxt.auth import Auth, TokenProvider
+from contxt.services.auth import AuthService
+from contxt.utils import make_logger
+
+logger = make_logger(__name__)
 
 
 class MachineTokenProvider(TokenProvider):
-    pass
-
-
-class MachineAuth(BaseAuth):
     """
-    Same as `BaseAuth`, but specifically for a non-human client, such as a
-    service, api, or worker.
+    Same as `TokenProvider`, but specifically for a non-human client. In this case,
+    `client_id` and `client_secret` serves as the identity provider for the source
+    client.
+    """
+
+    def __init__(self, client_id: str, client_secret: str, audience: str):
+        super().__init__(audience)
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.auth_service = AuthService()
+
+    @TokenProvider.access_token.getter
+    def access_token(self) -> str:
+        """Gets a valid access token for audience `audience`"""
+        if self._access_token is None or self._token_expiring():
+            # Token either not yet set or expiring soon, fetch one
+            logger.debug(f"Fetching new access_token for {self.audience}")
+            self.access_token = self.auth_service.get_oauth_token(
+                self.client_id, self.client_secret, self.audience
+            )
+        return self._access_token
+
+
+class MachineAuth(Auth):
+    """
+    Same as `Auth`, but specifically for a non-human client, such as a service,
+    api, or worker.
     """
 
     def get_token_provider(self, audience: str) -> MachineTokenProvider:

--- a/contxt/auth/machine.py
+++ b/contxt/auth/machine.py
@@ -1,14 +1,8 @@
 from contxt.auth import BaseAuth
-from contxt.utils import Config, make_logger
-
-logger = make_logger(__name__)
 
 
+# TODO: remove this class, as its just an alias around BaseAuth
 class MachineAuth(BaseAuth):
     """
-    Authentication for a service or worker
+    Authentication for a non-human client, such as a service, api, or worker
     """
-
-    def __init__(self, client_id, client_secret):
-        super().__init__(client_id=client_id, client_secret=client_secret)
-        # self.get_auth_token()

--- a/contxt/auth/machine.py
+++ b/contxt/auth/machine.py
@@ -1,8 +1,16 @@
-from contxt.auth import BaseAuth
+from contxt.auth import BaseAuth, TokenProvider
 
 
-# TODO: remove this class, as its just an alias around BaseAuth
+class MachineTokenProvider(TokenProvider):
+    pass
+
+
 class MachineAuth(BaseAuth):
     """
-    Authentication for a non-human client, such as a service, api, or worker
+    Same as `BaseAuth`, but specifically for a non-human client, such as a
+    service, api, or worker.
     """
+
+    def get_token_provider(self, audience: str) -> MachineTokenProvider:
+        """Get `MachineTokenProvider` for audience `audience`"""
+        return MachineTokenProvider(self.client_id, self.client_secret, audience)

--- a/contxt/auth/machine.py
+++ b/contxt/auth/machine.py
@@ -8,7 +8,7 @@ logger = make_logger(__name__)
 class MachineTokenProvider(TokenProvider):
     """
     Same as `TokenProvider`, but specifically for a non-human client. In this case,
-    `client_id` and `client_secret` serves as the identity provider for the source
+    `client_id` and `client_secret` serve as the identity provider for the source
     client.
     """
 

--- a/contxt/auth/machine.py
+++ b/contxt/auth/machine.py
@@ -33,7 +33,7 @@ class MachineTokenProvider(TokenProvider):
 class MachineAuth(Auth):
     """
     Same as `Auth`, but specifically for a non-human client, such as a service,
-    api, or worker.
+    API, or worker.
     """
 
     def get_token_provider(self, audience: str) -> MachineTokenProvider:

--- a/contxt/cli/parsers.py
+++ b/contxt/cli/parsers.py
@@ -42,7 +42,7 @@ class AuthParser(ContxtArgParser):
         auth.login()
 
     def _logout(self, args, auth):
-        auth.reset()
+        auth.logout()
 
 
 class IotParser(ContxtArgParser):

--- a/contxt/legacy/auth/__init__.py
+++ b/contxt/legacy/auth/__init__.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+from json import dump, load
+from pathlib import Path
+
+from auth0.v3.authentication import GetToken
+from jwt import decode
+
+from contxt.services.auth import ContxtAuthService
+from contxt.utils import Utils, make_logger
+
+logger = make_logger(__name__)
+
+
+class BaseAuth:
+    AUTH_AUDIENCE = "75wT048QcpE7ujwBJPPjr263eTHl4gEX"
+    CLI_CLIENT_ID = "bleED0RUwb7CJ9j7D48tqSiSZRZn29AV"
+    CLI_CLIENT_SECRET = (
+        "0s8VNQ26QrteS3H5KXIIPvkDcNL5PfT-_pWwAVNI4MpDaDg86O2XUH8lT19KLNiZ"
+    )
+
+    def __init__(self, client_id, client_secret=None, cli_mode=False):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.auth0 = GetToken("ndustrial.auth0.com")
+
+        self.contxt_config_path = Path.home() / ".contxt"
+        self.token_file = self.contxt_config_path / "tokens"
+
+        # load up the tokens we have
+        self.tokens = self.load_tokens()
+
+        self.auth_access_token = (
+            self.get_token_for_audience(self.AUTH_AUDIENCE)
+            if self.AUTH_AUDIENCE in self.tokens
+            else None
+        )
+
+        if not cli_mode:
+            self.contxt_auth = ContxtAuthService(
+                access_token=self.auth_access_token,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+            )
+        else:
+            # if there is no token for auth, then we need to go ask the user to login so we can get one
+            if not self.auth_access_token:
+                self.login()
+                self.auth_access_token = (
+                    self.get_token_for_audience(self.AUTH_AUDIENCE)
+                    if self.AUTH_AUDIENCE in self.tokens
+                    else None
+                )
+
+            self.contxt_auth = ContxtAuthService(access_token=self.auth_access_token)
+
+    def get_auth_token(self):
+        return self.auth_access_token
+
+    def set_auth_token(self, access_token, refresh_token=None):
+        self.auth_access_token = access_token
+        self.store_service_token(
+            audience=self.AUTH_AUDIENCE,
+            access_token=access_token,
+            refresh_token=refresh_token,
+        )
+
+    def refresh_contxt_auth_token(self):
+        logger.debug(f"Refreshing contxt auth token")
+        refresh_token = self.tokens[self.AUTH_AUDIENCE]["refresh_token"]
+        token = self.auth0.refresh_token(
+            client_id=self.client_id,
+            client_secret=self.client_secret or "",
+            refresh_token=refresh_token,
+        )
+
+        # store the new access token and re-store the existing refresh token
+        self.store_service_token(
+            audience=self.AUTH_AUDIENCE,
+            access_token=token["access_token"],
+            refresh_token=refresh_token,
+        )
+
+    def authenticate_to_service(self, service_audience):
+        logger.debug(f"Getting new token for {service_audience}")
+        token = self.contxt_auth.get_new_token_for_audience(service_audience)
+        self.store_service_token(audience=service_audience, access_token=token)
+        return token
+
+    def get_token_for_audience(self, audience):
+        logger.debug(f"Getting token for client {audience}")
+        # check to see if we've gotten a token for this service or not
+        if audience not in self.tokens:
+            # try to get a token, whether it's a refresh or not
+            self.authenticate_to_service(audience)
+
+        # check to see if have the token, but needs to be refreshed
+        if self.token_is_expired_for_audience(audience):
+            logger.warn(f"Refreshing expired token for client {audience}...")
+
+            # if it's the contxt auth client, we need to follow the other refresh route via Auth0
+            if audience == self.AUTH_AUDIENCE:
+                self.refresh_contxt_auth_token()
+            else:
+                self.authenticate_to_service(audience)
+
+        access_token = self.tokens[audience]["token"]
+        return access_token
+
+    def token_is_expired_for_audience(self, audience):
+        logger.debug(f"Checking if token is expired for audience {audience}")
+        if not self.tokens.get(audience):
+            return True
+        access_token = self.tokens[audience]["token"]
+        decoded_token = decode(access_token, verify=False)
+        token_expiration_epoch = decoded_token["exp"]
+
+        return token_expiration_epoch <= Utils.get_epoch_time(datetime.now())
+
+    def read_token_file(self):
+        logger.debug(f"Loading tokens from {self.token_file}")
+        self.contxt_config_path.mkdir(parents=True, exist_ok=True)
+
+        try:
+            with self.token_file.open("r") as f:
+                return load(f)
+        except FileNotFoundError:
+            logger.debug("Token file does not yet exist")
+            return {}
+
+    def load_tokens(self):
+        all_tokens = self.read_token_file()
+        return all_tokens.get(self.client_id, {})
+
+    def store_service_token(self, audience, access_token, refresh_token=None):
+
+        self.tokens.setdefault(self.client_id, {})
+        # if self.client_id not in self.tokens:
+        #     self.tokens[self.client_id] = {}
+
+        self.tokens[audience] = {"token": access_token, "refresh_token": refresh_token}
+
+        self.store_tokens(self.tokens)
+
+    def store_tokens(self, tokens_for_client):
+        logger.debug(f"Storing tokens to {self.token_file}")
+
+        all_tokens = self.read_token_file()
+        all_tokens[self.client_id] = tokens_for_client
+
+        with self.token_file.open("w") as f:
+            dump(all_tokens, f, indent=4)
+
+    def clear_tokens(self):
+        logger.debug(f"Removing toke file {self.token_file}")
+        self.token_file.unlink()

--- a/contxt/legacy/auth/__init__.py
+++ b/contxt/legacy/auth/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from auth0.v3.authentication import GetToken
 from jwt import decode
 
-from contxt.services.auth import ContxtAuthService
+from contxt.legacy.services.auth import ContxtAuthService
 from contxt.utils import Utils, make_logger
 
 logger = make_logger(__name__)

--- a/contxt/legacy/auth/cli.py
+++ b/contxt/legacy/auth/cli.py
@@ -1,0 +1,61 @@
+from getpass import getpass
+
+from contxt.legacy.auth import BaseAuth
+from contxt.utils import make_logger
+
+logger = make_logger(__name__)
+
+
+class CLIAuth(BaseAuth):
+    """
+    Authentication for a CLI user
+    """
+
+    def __init__(self, force_login=True):
+        super().__init__(client_id=self.CLI_CLIENT_ID, cli_mode=True)
+
+        if self.get_auth_token() is None and force_login:
+            logger.info(
+                "Token doesn't exist or can't be refreshed. Please re-authenticate"
+            )
+            self.login()
+
+    def _query_user(self, question):
+        accepted_answers = ["y", "n"]
+        ans = input(f"{question} ({'/'.join(accepted_answers)}) ").lower()[0:1]
+        while ans not in accepted_answers:
+            ans = input(f"Please enter {' or '.join(accepted_answers)}. ").lower()[0:1]
+        return ans == "y"
+
+    def login(self):
+
+        # Check login is needed
+        if self.get_auth_token() is not None:
+            if not self._query_user("Already logged in. Continue?"):
+                return
+
+        # Prompt for username/password
+        username = input("Contxt Username: ")
+        password = getpass("Contxt Password: ")
+
+        # Login
+        token = self.auth0.login(
+            client_id=self.CLI_CLIENT_ID,
+            client_secret=self.CLI_CLIENT_SECRET,
+            username=username,
+            password=password,
+            scope="offline_access",
+            audience=self.AUTH_AUDIENCE,
+            grant_type="password",
+            realm="",
+        )
+
+        # Store token
+        self.store_service_token(
+            audience=self.AUTH_AUDIENCE,
+            access_token=token["access_token"],
+            refresh_token=token["refresh_token"],
+        )
+
+    def reset(self):
+        self.clear_tokens()

--- a/contxt/legacy/auth/machine.py
+++ b/contxt/legacy/auth/machine.py
@@ -1,0 +1,13 @@
+from contxt.legacy.auth import BaseAuth
+from contxt.utils import make_logger
+
+logger = make_logger(__name__)
+
+
+class MachineAuth(BaseAuth):
+    """
+    Authentication for a service or worker
+    """
+
+    def __init__(self, client_id, client_secret):
+        super().__init__(client_id=client_id, client_secret=client_secret)

--- a/contxt/legacy/services/auth.py
+++ b/contxt/legacy/services/auth.py
@@ -1,0 +1,79 @@
+from contxt.legacy.services import POST, ApiRequest, Service
+from contxt.utils import make_logger
+
+CONFIGS_BY_ENVIRONMENT = {
+    "production": {
+        "base_url": "https://contxtauth.com",
+        "audience": "75wT048QcpE7ujwBJPPjr263eTHl4gEX",
+    }
+}
+
+logger = make_logger(__name__)
+
+
+class AuthConfigurationError(Exception):
+    pass
+
+
+class ContxtAuthService(Service):
+    """
+    Service to interact with our Contxt Auth API.
+    """
+
+    def __init__(
+        self, access_token, client_id=None, client_secret=None, environment="production"
+    ):
+
+        if environment not in CONFIGS_BY_ENVIRONMENT:
+            raise Exception("Invalid environment specified")
+
+        self.env = CONFIGS_BY_ENVIRONMENT[environment]
+
+        # can imply if access_token is none, then we need to use client_id/client_secret to get tokens
+        self.access_token = access_token
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+        if self.access_token is None:
+            logger.info("Implying machine-based authentication")
+
+            if self.client_id is None or self.client_secret is None:
+                raise AuthConfigurationError(
+                    "Misconfiguration authentication. When implying machine-based "
+                    "authentication client_id and client_secret must be provided"
+                )
+
+        super().__init__(base_url=self.env["base_url"], access_token=access_token)
+
+    def get_new_token_for_audience(self, audience):
+
+        if not self.client_id:
+            body = {"audiences": [audience]}
+
+            response = self.execute(
+                POST(uri="token")
+                .body(body)
+                .content_type(ApiRequest.URLENCODED_CONTENT_TYPE),
+                execute=True,
+            )
+
+            return response["access_token"]
+
+        else:
+
+            body = {
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "audience": audience,
+                "grant_type": "client_credentials",
+            }
+
+            response = self.execute(
+                POST(uri="oauth/token")
+                .body(body)
+                .content_type(ApiRequest.URLENCODED_CONTENT_TYPE)
+                .authorize(False),
+                execute=True,
+            )
+
+            return response["access_token"]

--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -13,7 +13,7 @@ from requests import PreparedRequest, Response, Session
 from requests.auth import AuthBase
 from requests.exceptions import HTTPError
 
-# from contxt.auth import TokenProvider
+from contxt.auth import TokenProvider
 from contxt.utils import make_logger
 from contxt.utils.serializer import Serializer
 
@@ -114,7 +114,7 @@ class RequestAuth(AuthBase):
     Authorization passed to requests (sets bearer access token in request header)
     """
 
-    def __init__(self, token_provider: "TokenProvider") -> None:
+    def __init__(self, token_provider: TokenProvider) -> None:
         self.token_provider = token_provider
 
     def __call__(self, request: PreparedRequest):
@@ -134,7 +134,7 @@ class ApiService:
     def __init__(
         self,
         base_url: str,
-        token_provider: Optional["TokenProvider"] = None,
+        token_provider: Optional[TokenProvider] = None,
         use_session: Optional[bool] = True,
     ):
         self.base_url = base_url

--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -19,8 +19,6 @@ from contxt.utils.serializer import Serializer
 
 logger = make_logger(__name__)
 
-API_VERSION = "v1"
-
 
 def warn_of_unexpected_api_keys(cls, kwargs):
     # Warn of unexpected kwargs
@@ -137,12 +135,10 @@ class ApiService:
         self,
         base_url: str,
         token_provider: Optional["TokenProvider"] = None,
-        api_version: Optional[str] = __marker,
         use_session: Optional[bool] = True,
     ):
-        api_version = API_VERSION if api_version is self.__marker else api_version
+        self.base_url = base_url
         self.token_provider = token_provider
-        self.base_url = self._init_base_url(base_url, api_version)
         self.session = self._init_session() if use_session else None
 
     def _init_session(self):
@@ -151,9 +147,6 @@ class ApiService:
             session.auth = RequestAuth(self.token_provider)
         session.hooks = {"response": self._log_response}
         return session
-
-    def _init_base_url(self, base_url: str, api_version: str) -> str:
-        return f"{base_url}/{api_version}" if api_version else base_url
 
     def _url(self, uri: str) -> str:
         return f"{self.base_url}/{uri}"

--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -13,7 +13,7 @@ from requests import PreparedRequest, Response, Session
 from requests.auth import AuthBase
 from requests.exceptions import HTTPError
 
-from contxt.auth import TokenProvider
+# from contxt.auth import TokenProvider
 from contxt.utils import make_logger
 from contxt.utils.serializer import Serializer
 
@@ -116,7 +116,7 @@ class RequestAuth(AuthBase):
     Authorization passed to requests (sets bearer access token in request header)
     """
 
-    def __init__(self, token_provider: TokenProvider) -> None:
+    def __init__(self, token_provider: "TokenProvider") -> None:
         self.token_provider = token_provider
 
     def __call__(self, request: PreparedRequest):
@@ -136,7 +136,7 @@ class ApiService:
     def __init__(
         self,
         base_url: str,
-        token_provider: Optional[TokenProvider] = None,
+        token_provider: Optional["TokenProvider"] = None,
         api_version: Optional[str] = __marker,
         use_session: Optional[bool] = True,
     ):

--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -4,16 +4,16 @@ from abc import ABC, abstractmethod
 from ast import literal_eval
 from datetime import date, datetime
 from importlib import import_module
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import requests
 from dateutil import parser
-from jwt import decode
 from pytz import UTC, ZERO
 from requests import PreparedRequest, Response, Session
 from requests.auth import AuthBase
 from requests.exceptions import HTTPError
 
+from contxt.auth import TokenProvider
 from contxt.utils import make_logger
 from contxt.utils.serializer import Serializer
 
@@ -116,39 +116,39 @@ class RequestAuth(AuthBase):
     Authorization passed to requests (sets bearer access token in request header)
     """
 
-    def __init__(self, access_token: str) -> None:
-        self.access_token = access_token
+    def __init__(self, token_provider: TokenProvider) -> None:
+        self.token_provider = token_provider
 
     def __call__(self, request: PreparedRequest):
-        request.headers['Authorization'] = f'Bearer {self.access_token}'
+        request.headers["Authorization"] = f"Bearer {self.token_provider.access_token}"
         return request
-
-
-class ApiClient:
-
-    def __init__(self, access_token: str) -> None:
-        self.access_token = access_token
 
 
 class ApiService:
     """
-    A service associated with an API
+    A service associated with an API.
+
+    If `token_provided` is specified, all requests with be authenticated with
+    the access_token it provides.
     """
     __marker = object()
 
-    def __init__(self,
-                 base_url: str,
-                 access_token: str,
-                 api_version: Optional[str] = __marker,
-                 use_session: Optional[bool] = True):
+    def __init__(
+        self,
+        base_url: str,
+        token_provider: Optional[TokenProvider] = None,
+        api_version: Optional[str] = __marker,
+        use_session: Optional[bool] = True,
+    ):
         api_version = API_VERSION if api_version is self.__marker else api_version
-        self.client = ApiClient(access_token)
+        self.token_provider = token_provider
         self.base_url = self._init_base_url(base_url, api_version)
         self.session = self._init_session() if use_session else None
 
     def _init_session(self):
         session = Session()
-        session.auth = RequestAuth(self.client.access_token)
+        if self.token_provider:
+            session.auth = RequestAuth(self.token_provider)
         session.hooks = {"response": self._log_response}
         return session
 
@@ -160,11 +160,9 @@ class ApiService:
 
     def _request_kwargs(self):
         return {
-            "auth": RequestAuth(self.client.access_token),
+            "auth": RequestAuth(self.token_provider) if self.token_provider else None,
             # "timeout": 1,
-            "hooks": {
-                "response": self._log_response
-            }
+            "hooks": {"response": self._log_response},
         }
 
     def _log_response(self, response: Response, *args, **kwargs):
@@ -195,10 +193,11 @@ class ApiService:
         except ValueError as e:
             return {}
 
-    def get_logged_in_user_id(self) -> str:
+    def get_logged_in_user_id(self) -> Optional[str]:
+        if not self.token_provider:
+            return None
         # TODO do actual token verification
-        decoded_token = decode(self.client.access_token, verify=False)
-        return decoded_token['sub']
+        return self.token_provider.decoded_access_token["sub"]
 
     def get(self,
             uri,
@@ -275,7 +274,6 @@ class ApiServiceConfig:
         self.audience = audience
 
 
-# TODO: we should automatically refresh the access token here
 class ConfiguredApiService(ApiService, ABC):
     """
     An ApiService that has a list of configurations, selected by name
@@ -284,10 +282,12 @@ class ConfiguredApiService(ApiService, ABC):
     def __init__(self, auth, env: str, **kwargs):
         self.auth = auth
         self.config = self._init_config(env)
+        token_provider = (
+            self.auth.get_token_provider(self.config.audience) if self.auth else None
+        )
         super().__init__(
-            base_url=self.config.base_url,
-            access_token=auth.get_token_for_audience(self.config.audience),
-            **kwargs)
+            base_url=self.config.base_url, token_provider=token_provider, **kwargs
+        )
 
     @property
     @abstractmethod

--- a/contxt/services/assets.py
+++ b/contxt/services/assets.py
@@ -18,11 +18,11 @@ class AssetsService(ConfiguredApiService):
     _configs = (
         ApiServiceConfig(
             name="production",
-            base_url="https://facilities.api.ndustrial.io",
+            base_url="https://facilities.api.ndustrial.io/v1",
             audience="SgbCopArnGMa9PsRlCVUCVRwxocntlg0"),
         ApiServiceConfig(
             name="staging",
-            base_url="https://facilities-staging.api.ndustrial.io",
+            base_url="https://facilities-staging.api.ndustrial.io/v1",
             audience="xG775XHIOZVUn84seNeHXi0Qe55YuR5w"),
     )
 

--- a/contxt/services/assets.py
+++ b/contxt/services/assets.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from contxt.auth import BaseAuth
+from contxt.auth import Auth
 from contxt.models.assets import (Asset, AssetType, Attribute, AttributeValue,
                                   CompleteAsset, Metric, MetricValue)
 from contxt.services.api import ApiServiceConfig, ConfiguredApiService
@@ -28,7 +28,7 @@ class AssetsService(ConfiguredApiService):
 
     def __init__(
             self,
-            auth: BaseAuth,
+            auth: Auth,
             organization_id: str,
             env: str = "production",
             load_types: bool = True,

--- a/contxt/services/assets.py
+++ b/contxt/services/assets.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from contxt.auth.cli import CLIAuth
+from contxt.auth import BaseAuth
 from contxt.models.assets import (Asset, AssetType, Attribute, AttributeValue,
                                   CompleteAsset, Metric, MetricValue)
 from contxt.services.api import ApiServiceConfig, ConfiguredApiService
@@ -28,7 +28,7 @@ class AssetsService(ConfiguredApiService):
 
     def __init__(
             self,
-            auth: CLIAuth,
+            auth: BaseAuth,
             organization_id: str,
             env: str = "production",
             load_types: bool = True,

--- a/contxt/services/auth.py
+++ b/contxt/services/auth.py
@@ -1,70 +1,41 @@
-from contxt.legacy.services import POST, ApiRequest, Service
+from contxt.services.api import ApiServiceConfig, ConfiguredApiService
 from contxt.utils import make_logger
-
-CONFIGS_BY_ENVIRONMENT = {
-    'production': {
-        'base_url': 'https://contxtauth.com',
-        'audience': '75wT048QcpE7ujwBJPPjr263eTHl4gEX'
-    }
-}
 
 logger = make_logger(__name__)
 
 
-class AuthConfigurationError(Exception):
-    pass
-
-
-class ContxtAuthService(Service):
+class AuthService(ConfiguredApiService):
     """
-    Service to interact with our Contxt Auth API.
+    Service to interact with our Auth API.
     """
 
-    def __init__(self, access_token, client_id=None, client_secret=None, environment='production'):
+    _configs = (
+        ApiServiceConfig(
+            name="production",
+            base_url="https://contxtauth.com",
+            audience="75wT048QcpE7ujwBJPPjr263eTHl4gEX",
+        ),
+    )
 
-        if environment not in CONFIGS_BY_ENVIRONMENT:
-            raise Exception('Invalid environment specified')
+    def __init__(self, env: str = "production"):
+        super().__init__(None, env)
 
-        self.env = CONFIGS_BY_ENVIRONMENT[environment]
+    def get_token(self, access_token: str, audience: str) -> str:
+        response = self.post(
+            "token",
+            json={"audiences": [audience]},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        return response["access_token"]
 
-        # can imply if access_token is none, then we need to use client_id/client_secret to get tokens
-        self.access_token = access_token
-        self.client_id = client_id
-        self.client_secret = client_secret
-
-        if self.access_token is None:
-            logger.info("Implying machine-based authentication")
-
-            if self.client_id is None or self.client_secret is None:
-                raise AuthConfigurationError("Misconfiguration authentication. When implying machine-based "
-                                             "authentication client_id and client_secret must be provided")
-
-        super().__init__(
-            base_url=self.env['base_url'], access_token=access_token)
-
-    def get_new_token_for_audience(self, audience):
-
-        if not self.client_id:
-            body = {
-                'audiences': [audience]
-            }
-
-            response = self.execute(POST(uri='token').body(body)
-                                    .content_type(ApiRequest.URLENCODED_CONTENT_TYPE), execute=True)
-
-            return response['access_token']
-
-        else:
-
-            body = {
-                'client_id': self.client_id,
-                'client_secret': self.client_secret,
-                'audience': audience,
-                'grant_type': 'client_credentials'
-            }
-
-            response = self.execute(POST(uri='oauth/token').body(body)
-                                    .content_type(ApiRequest.URLENCODED_CONTENT_TYPE)
-                                    .authorize(False), execute=True)
-
-            return response['access_token']
+    def get_oauth_token(self, client_id: str, client_secret: str, audience: str) -> str:
+        response = self.post(
+            "oauth/token",
+            json={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "audience": audience,
+                "grant_type": "client_credentials",
+            },
+        )
+        return response["access_token"]

--- a/contxt/services/auth.py
+++ b/contxt/services/auth.py
@@ -39,3 +39,6 @@ class AuthService(ConfiguredApiService):
             },
         )
         return response["access_token"]
+
+    def get_jwks(self) -> str:
+        return self.get(".well-known/jwks.json")

--- a/contxt/services/auth.py
+++ b/contxt/services/auth.py
@@ -14,7 +14,7 @@ class AuthService(ConfiguredApiService):
     _configs = (
         ApiServiceConfig(
             name="production",
-            base_url="https://contxtauth.com",
+            base_url="https://contxtauth.com/v1",
             audience="75wT048QcpE7ujwBJPPjr263eTHl4gEX",
         ),
     )

--- a/contxt/services/auth.py
+++ b/contxt/services/auth.py
@@ -1,3 +1,5 @@
+from typing import List, Union
+
 from contxt.services.api import ApiServiceConfig, ConfiguredApiService
 from contxt.utils import make_logger
 
@@ -20,10 +22,11 @@ class AuthService(ConfiguredApiService):
     def __init__(self, env: str = "production"):
         super().__init__(None, env)
 
-    def get_token(self, access_token: str, audience: str) -> str:
+    def get_token(self, access_token: str, audiences: Union[str, List[str]]) -> str:
+        audiences = [audiences] if isinstance(audiences, str) else audiences
         response = self.post(
             "token",
-            json={"audiences": [audience]},
+            json={"audiences": audiences},
             headers={"Authorization": f"Bearer {access_token}"},
         )
         return response["access_token"]

--- a/contxt/services/bus.py
+++ b/contxt/services/bus.py
@@ -16,7 +16,7 @@ class MessageBusService(ConfiguredApiService):
         ApiServiceConfig(
             name="production",
             base_url="https://bus.ndustrial.io",
-            # base_url="http://bus.lineageapi.com/",
+            # base_url="http://bus.lineageapi.com",
             audience="T62CR77ouw4I6VPlSSlLT9VpVA1ebByx"),
         ApiServiceConfig(
             name="staging",
@@ -30,7 +30,7 @@ class MessageBusService(ConfiguredApiService):
             organization_id: str,
             env: Optional[str] = "production",
     ):
-        super().__init__(auth, env, api_version=None)
+        super().__init__(auth, env)
         self.organization_id = organization_id
 
     def _channels_url(self, service_id):

--- a/contxt/services/bus.py
+++ b/contxt/services/bus.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional, Set, Tuple
 
-from contxt.auth import BaseAuth
+from contxt.auth import Auth
 from contxt.models.bus import Channel, ChannelStats
 from contxt.services.api import ApiServiceConfig, ConfiguredApiService
 from contxt.utils import make_logger
@@ -26,7 +26,7 @@ class MessageBusService(ConfiguredApiService):
 
     def __init__(
             self,
-            auth: BaseAuth,
+            auth: Auth,
             organization_id: str,
             env: Optional[str] = "production",
     ):

--- a/contxt/services/contxt.py
+++ b/contxt/services/contxt.py
@@ -17,11 +17,11 @@ class ContxtService(ConfiguredApiService):
     _configs = (
         ApiServiceConfig(
             name="production",
-            base_url="https://contxt.api.ndustrial.io",
+            base_url="https://contxt.api.ndustrial.io/v1",
             audience="8qY2xJob1JAxhmVhIDLCNnGriTM9bct8"),
         ApiServiceConfig(
             name="staging",
-            base_url="https://contxt-staging.api.ndustrial.io",
+            base_url="https://contxt-staging.api.ndustrial.io/v1",
             audience="8qY2xJob1JAxhmVhIDLCNnGriTM9bct8"),
     )
 

--- a/contxt/services/contxt.py
+++ b/contxt/services/contxt.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import List
 
-from contxt.auth.cli import CLIAuth
+from contxt.auth import BaseAuth
 from contxt.models.contxt import (Config, ConfigValue, Organization,
                                   OrganizationUser, User)
 from contxt.services.api import ApiServiceConfig, ConfiguredApiService
@@ -25,7 +25,7 @@ class ContxtService(ConfiguredApiService):
             audience="8qY2xJob1JAxhmVhIDLCNnGriTM9bct8"),
     )
 
-    def __init__(self, auth: CLIAuth, env: str = "production"):
+    def __init__(self, auth: BaseAuth, env: str = "production"):
         super().__init__(auth, env)
 
     def get_organizations(self) -> List[Organization]:

--- a/contxt/services/contxt.py
+++ b/contxt/services/contxt.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List
 
-from contxt.auth import BaseAuth
+from contxt.auth import Auth
 from contxt.models.contxt import (Config, ConfigValue, Organization,
                                   OrganizationUser, User)
 from contxt.services.api import ApiServiceConfig, ConfiguredApiService
@@ -25,7 +25,7 @@ class ContxtService(ConfiguredApiService):
             audience="8qY2xJob1JAxhmVhIDLCNnGriTM9bct8"),
     )
 
-    def __init__(self, auth: BaseAuth, env: str = "production"):
+    def __init__(self, auth: Auth, env: str = "production"):
         super().__init__(auth, env)
 
     def get_organizations(self) -> List[Organization]:

--- a/contxt/services/ems.py
+++ b/contxt/services/ems.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Optional
 
 from contxt.legacy.services import GET, APIObjectCollection, Service
 from contxt.models.ems import (FacilityMainService, FacilityUtilitySpend,
@@ -22,7 +22,7 @@ class EMSService(Service):
     Service to interact with our EMS API.
     """
 
-    def __init__(self, auth_module, environment='production'):
+    def __init__(self, auth, environment='production'):
 
         if environment not in CONFIGS_BY_ENVIRONMENT:
             raise Exception('Invalid environment specified')
@@ -31,8 +31,7 @@ class EMSService(Service):
 
         super().__init__(
             base_url=self.env['base_url'],
-            access_token=auth_module.get_token_for_audience(
-                self.env['audience']))
+            access_token=auth.get_token_provider(self.env['audience']))
 
     def get_main_services(self, facility_id: int, type: Optional[str] = None):
 
@@ -58,8 +57,8 @@ class EMSService(Service):
             type: str,
             date_start: datetime,
             date_end: datetime,
-            pro_forma: Optional[bool] = False,
-            exclude_account_charges: Optional[bool] = False,
+            pro_forma: bool = False,
+            exclude_account_charges: bool = False,
     ):
         params = {
             'type': type,
@@ -82,7 +81,7 @@ class EMSService(Service):
             type: str,
             date_start: datetime,
             date_end: datetime,
-            pro_forma: Optional[bool] = False,
+            pro_forma: bool = False,
     ):
 
         params = {

--- a/contxt/services/events.py
+++ b/contxt/services/events.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import List
 
-from contxt.auth.cli import CLIAuth
+from contxt.auth import BaseAuth
 from contxt.models.events import (Event, EventDefinition, EventType,
                                   TriggeredEvent)
 from contxt.services.api import ApiServiceConfig, ConfiguredApiService
@@ -26,7 +26,7 @@ class EventsService(ConfiguredApiService):
 
     def __init__(
             self,
-            auth: CLIAuth,
+            auth: BaseAuth,
             env: str = "production"
     ):
         super().__init__(auth, env)

--- a/contxt/services/events.py
+++ b/contxt/services/events.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from contxt.auth import BaseAuth
+from contxt.auth import Auth
 from contxt.models.events import (Event, EventDefinition, EventType,
                                   TriggeredEvent)
 from contxt.services.api import ApiServiceConfig, ConfiguredApiService
@@ -26,7 +26,7 @@ class EventsService(ConfiguredApiService):
 
     def __init__(
             self,
-            auth: BaseAuth,
+            auth: Auth,
             env: str = "production"
     ):
         super().__init__(auth, env)

--- a/contxt/services/events.py
+++ b/contxt/services/events.py
@@ -16,11 +16,11 @@ class EventsService(ConfiguredApiService):
     _configs = (
         ApiServiceConfig(
             name="production",
-            base_url="http://events.api.ndustrial.io",
+            base_url="http://events.api.ndustrial.io/v1",
             audience="7jzwfE20O2XZ4aq3cO1wmk63G9GzNc8j"),
         ApiServiceConfig(
             name="staging",
-            base_url="http://events-staging.api.ndustrial.io",
+            base_url="http://events-staging.api.ndustrial.io/v1",
             audience="dn4MaocJFdKtsBy9sFFaTeuJWL1nt5xu"),
     )
 

--- a/contxt/services/facilities.py
+++ b/contxt/services/facilities.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from contxt.auth import BaseAuth
+from contxt.auth import Auth
 from contxt.models.facilities import Facility
 from contxt.services.api import ConfiguredApiService
 from contxt.services.assets import AssetsService
@@ -17,7 +17,7 @@ class FacilitiesService(ConfiguredApiService):
     """
     _configs = AssetsService._configs
 
-    def __init__(self, auth: BaseAuth, env: str = "production"):
+    def __init__(self, auth: Auth, env: str = "production"):
         super().__init__(auth, env)
 
     def get_facilities(self, organization_id: Optional[str] = None):

--- a/contxt/services/facilities.py
+++ b/contxt/services/facilities.py
@@ -1,6 +1,6 @@
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Optional
 
-from contxt.auth.cli import CLIAuth
+from contxt.auth import BaseAuth
 from contxt.models.facilities import Facility
 from contxt.services.api import ConfiguredApiService
 from contxt.services.assets import AssetsService
@@ -17,7 +17,7 @@ class FacilitiesService(ConfiguredApiService):
     """
     _configs = AssetsService._configs
 
-    def __init__(self, auth: CLIAuth, env: str = "production"):
+    def __init__(self, auth: BaseAuth, env: str = "production"):
         super().__init__(auth, env)
 
     def get_facilities(self, organization_id: Optional[str] = None):

--- a/contxt/services/iot.py
+++ b/contxt/services/iot.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Optional
 
 from contxt.legacy.services import (GET, APIObjectCollection, DataResponse,
                                     PagedEndpoint, PagedResponse, Service)
@@ -20,7 +20,7 @@ class IOTService(Service):
     Service to interact with our IOT API.
     """
 
-    def __init__(self, auth_module, environment='production'):
+    def __init__(self, auth, environment='production'):
 
         if environment not in CONFIGS_BY_ENVIRONMENT:
             raise Exception("Invalid environment specified")
@@ -29,7 +29,7 @@ class IOTService(Service):
 
         super().__init__(
             base_url=self.env["base_url"],
-            access_token=auth_module.get_token_for_audience(self.env["audience"]),
+            access_token=auth.get_token_provider(self.env["audience"]),
         )
 
     def get_all_groupings(self, facility_id: int):
@@ -79,7 +79,7 @@ class IOTService(Service):
             start_time: datetime,
             window: int,
             end_time: Optional[datetime] = None,
-            limit: Optional[int] = 1000,
+            limit: int = 1000,
     ):
 
         params = {

--- a/contxt/utils/__init__.py
+++ b/contxt/utils/__init__.py
@@ -1,9 +1,9 @@
 import logging
-import sys
 from datetime import datetime
-from os import environ
+from sys import stdout
+from time import time
 
-import pytz
+from pytz import UTC
 from tzlocal import get_localzone
 
 
@@ -14,22 +14,23 @@ def make_logger(name, level=None):
     return logger
 
 
+def timed(func):
+    def wrapper(*args, **kwargs):
+        t0 = time()
+        return_val = func(*args, **kwargs)
+        print(f"{func.__name__}'s elapsed time: {time() - t0} s")
+        return return_val
+
+    return wrapper
+
+
 class Utils:
     __marker = object()
 
     @staticmethod
-    def get_environ_var(var, default=__marker):
-        if var not in environ:
-            if default is Utils.__marker:
-                raise EnvironmentError(
-                    f'Variable {var} is missing from the environment')
-            return default
-        return environ[var]
-
-    @staticmethod
     def delocalize_datetime(dt_object):
         localized_dt = get_localzone().localize(dt_object)
-        return localized_dt.astimezone(pytz.utc)
+        return localized_dt.astimezone(UTC)
 
     @staticmethod
     def get_epoch_time(dt_object):
@@ -38,9 +39,9 @@ class Utils:
             # as set on the system,
             dt_object = get_localzone().localize(dt_object)
 
-        utc_1970 = datetime(1970, 1, 1).replace(tzinfo=pytz.utc)
+        utc_1970 = datetime(1970, 1, 1).replace(tzinfo=UTC)
 
-        return int((dt_object.astimezone(pytz.utc) - utc_1970).total_seconds())
+        return int((dt_object.astimezone(UTC) - utc_1970).total_seconds())
 
     @staticmethod
     def dict_to_set(dict_):
@@ -57,25 +58,12 @@ class Utils:
 
     @staticmethod
     def set_to_dict(set_):
-
         def expand(obj):
             if isinstance(obj, (set, tuple)):
                 return {k: expand(v) for k, v in obj}
             return obj
 
         return expand(set_)
-
-
-class Envs:
-    staging = '4a9cfc2b-2580-4d01-8e67-0ea176296746'
-    production = 'production'
-
-
-class Config:
-    ENV = Utils.get_environ_var('WORKER_ENV', Envs.staging)     # TODO: no longer used
-    AUTH_AUDIENCE_ID = '75wT048QcpE7ujwBJPPjr263eTHl4gEX'
-    CLI_CLIENT_ID = 'bleED0RUwb7CJ9j7D48tqSiSZRZn29AV'
-    CLI_CLIENT_SECRET = '0s8VNQ26QrteS3H5KXIIPvkDcNL5PfT-_pWwAVNI4MpDaDg86O2XUH8lT19KLNiZ'
 
 
 # Define logger
@@ -91,18 +79,17 @@ COLOR_SEQ = "\033[0;%dm"
 BOLD_SEQ = "\033[1m"
 
 COLORS = {
-    'WARNING': YELLOW,
-    'INFO': WHITE,
-    'DEBUG': BLUE,
-    'CRITICAL': RED,
-    'ERROR': RED
+    "WARNING": YELLOW,
+    "INFO": WHITE,
+    "DEBUG": BLUE,
+    "CRITICAL": RED,
+    "ERROR": RED,
 }
 
 
 def formatter_message(message, use_color=True):
     if use_color:
-        message = message.replace("$RESET", RESET_SEQ).replace(
-            "$BOLD", BOLD_SEQ)
+        message = message.replace("$RESET", RESET_SEQ).replace("$BOLD", BOLD_SEQ)
     else:
         message = message.replace("$RESET", "").replace("$BOLD", "")
     return message
@@ -115,14 +102,16 @@ class ColoredFormatter(logging.Formatter):
 
     def format(self, record):
         level_color = COLOR_SEQ % (30 + COLORS[record.levelname])
-        log = logging.Formatter.format(self, record).replace('$COLOR', level_color)
+        log = logging.Formatter.format(self, record).replace("$COLOR", level_color)
         return log
 
 
 # Custom logger class with multiple destinations
 class ColoredLogger(logging.Logger):
-    FORMAT = "$COLOR%(asctime)s $BOLD$COLOR%(levelname)-8s$RESET$COLOR [%(name)s]  %(message)s (%(filename)s:%(" \
-             "lineno)d)$RESET "
+    FORMAT = (
+        "$COLOR%(asctime)s $BOLD$COLOR%(levelname)-8s$RESET$COLOR [%(name)s]  %(message)s (%(filename)s:%("
+        "lineno)d)$RESET "
+    )
     COLOR_FORMAT = formatter_message(FORMAT, True)
 
     def __init__(self, name):
@@ -130,14 +119,17 @@ class ColoredLogger(logging.Logger):
 
         color_formatter = ColoredFormatter(self.COLOR_FORMAT)
 
-        console = logging.StreamHandler(stream=sys.stdout)
+        console = logging.StreamHandler(stream=stdout)
         console.setFormatter(color_formatter)
 
         self.addHandler(console)
 
 
-if environ.get('WORKER_ENV') is not [Envs.production]:
+if True:
     logging.setLoggerClass(ColoredLogger)
 else:
-    logging.basicConfig(format="%(asctime)s %(levelname)-8s [%(name)s]  %(message)s (%(filename)s:%(lineno)d)",
-                        stream=sys.stdout, level=logging.INFO)
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)-8s [%(name)s]  %(message)s (%(filename)s:%(lineno)d)",
+        stream=stdout,
+        level=logging.INFO,
+    )

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
         "inflect",
         "pandas",
         "plotly",
-        "pyjwt",
         "python-dateutil",
         "pytz",
         "requests",

--- a/tests/integration/it.py
+++ b/tests/integration/it.py
@@ -1,6 +1,6 @@
 from requests.exceptions import HTTPError
 
-from contxt.auth.cli import CLIAuth
+from contxt.auth import CliAuth
 from contxt.services.assets import AssetsService
 from contxt.services.bus import MessageBusService
 from contxt.services.contxt import ContxtService
@@ -11,7 +11,7 @@ from contxt.utils import make_logger
 logger = make_logger(__name__)
 
 if __name__ == "__main__":
-    auth = CLIAuth()
+    auth = CliAuth()
     c = ContxtService(auth)
     ll = c.get_organization_with_name("Lineage Logistics")
     wpe = c.get_organization_with_name("Western Plains Energy")

--- a/tests/integration/it_assets.py
+++ b/tests/integration/it_assets.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timedelta
 import pytest
 from pytz import UTC
 
-from contxt.auth.cli import CLIAuth
+from contxt.auth import CliAuth
 from contxt.models.assets import (Asset, AssetType, Attribute, AttributeValue,
                                   DataTypes, Metric, MetricValue,
                                   TimeIntervals)
@@ -15,7 +15,7 @@ from tests.static.asset_schema import AssetSchemas
 def init_schema():
     organization_id = "02efa741-a96f-4124-a463-ae13a704b8fc"
     asset_framework = AssetsService(
-        auth=CLIAuth(),
+        auth=CliAuth(),
         organization_id=organization_id,
         env="staging",
         load_types=True)
@@ -42,11 +42,11 @@ TEST_ASSET = init_schema()
 
 @pytest.fixture
 def cli_auth():
-    return CLIAuth()
+    return CliAuth()
 
 
 @pytest.fixture
-def asset_framework(cli_auth: CLIAuth,
+def asset_framework(cli_auth: CliAuth,
                     organization_id="02efa741-a96f-4124-a463-ae13a704b8fc"):
     return AssetsService(cli_auth, organization_id, env="staging", load_types=True, types_to_fully_load=['TestParentType'])
 
@@ -310,6 +310,6 @@ class TestAssetsService:
 
 
 if __name__ == "__main__":
-    auth = CLIAuth()
+    auth = CliAuth()
     organization_id = "02efa741-a96f-4124-a463-ae13a704b8fc"
     af = AssetsService(auth, organization_id, env="staging")

--- a/tests/services/test_auth.py
+++ b/tests/services/test_auth.py
@@ -1,12 +1,14 @@
+from datetime import datetime
+
 from jose import jwt
 from jose.constants import ALGORITHMS
+from pytz import UTC
 
+from contxt.auth import TokenProvider
 from contxt.auth.jwt import (AuthError, AuthTokenValidator,
                              ContxtAuthTokenValidator)
 
-
-def test_auth():
-    private_key = """\
+PRIVATE_KEY = """\
 -----BEGIN RSA PRIVATE KEY-----
 MIICXAIBAAKBgQC1MZ30SIuWmPgbZcjhoyjauGw4mkzuds/QPGxqhykAs5+3iIzg
 zJSLehb9LLrGNzufl2OPu5Bza8LEXpprO8sevajfyOQ45SZ1Kbm0ILrYaLfl1yvF
@@ -23,7 +25,8 @@ l+J72CvnjnKG/1awo3zl3kJnQshrxn0HGQJBAMt/QUu0q7goczbWNxMXJNcZMfXU
 V2Ll5aCxsfioYdKx+8BIyFLgxGPw0ePpwbmIWeDIa3k=
 -----END RSA PRIVATE KEY-----
 """
-    public_key = """\
+
+PUBLIC_KEY = """\
 -----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC1MZ30SIuWmPgbZcjhoyjauGw4
 mkzuds/QPGxqhykAs5+3iIzgzJSLehb9LLrGNzufl2OPu5Bza8LEXpprO8sevajf
@@ -31,23 +34,72 @@ yOQ45SZ1Kbm0ILrYaLfl1yvFr6MqHrO07HWsiW9zoHDFU31sd2CoGJsu35fTils1
 /9Cq7+oWErNfJ61ZPQIDAQAB
 -----END PUBLIC KEY-----
 """
-    audience = 'foo_audience'
-    issuer = 'foo_issuer'
-    claims = {'foo': 'bar', 'aud': audience, 'iss': issuer}
-    token = jwt.encode(claims, private_key, algorithm=ALGORITHMS.RS256)
-    validator = AuthTokenValidator(audience=audience, issuer=issuer, public_key=public_key)
-    payload = validator.validate(token)
-    assert claims == payload
 
 
-def test_contxt_auth():
-    token_validator = ContxtAuthTokenValidator(audience='foo_audience')
-    try:
-        token_validator.validate('bad_token')
-        raise AssertionError("Token validation should have raised a token error before")
-    except AuthError:
-        pass
+class TestAuthTokenValidator:
+    def main(self):
+        self.test_auth()
+
+    def test_auth(self):
+        audience = "foo_audience"
+        issuer = "foo_issuer"
+        claims = {"foo": "bar", "aud": audience, "iss": issuer}
+        token = jwt.encode(claims, PRIVATE_KEY, algorithm=ALGORITHMS.RS256)
+        validator = AuthTokenValidator(
+            audience=audience, issuer=issuer, public_key=PUBLIC_KEY
+        )
+        payload = validator.validate(token)
+        assert claims == payload
 
 
-if __name__ == '__main__':
-    test_contxt_auth()
+class TestContxtAuthTokenValidator:
+    def main(self):
+        self.test_contxt_auth()
+
+    def test_contxt_auth(self):
+        token_validator = ContxtAuthTokenValidator(audience="foo_audience")
+        try:
+            token_validator.validate("bad_token")
+            raise AssertionError(
+                "Token validation should have raised a token error before"
+            )
+        except AuthError:
+            pass
+
+
+class TestTokenProvider:
+    claims = {"foo": "bar", "aud": "foo_audience", "iss": "foo_issuer"}
+
+    class DummyTokenProvider(TokenProvider):
+        @TokenProvider.access_token.getter
+        def access_token(self):
+            if self._access_token is None or self._token_expiring(within=0):
+                self._claims = {
+                    **TestTokenProvider.claims,
+                    "exp": datetime.now(UTC).timestamp(),
+                }
+                self.access_token = jwt.encode(
+                    self._claims, PRIVATE_KEY, algorithm=ALGORITHMS.RS256
+                )
+            return self._access_token
+
+    def main(self):
+        self.test_token_provider()
+
+    def test_token_provider(self):
+        token_provider = self.DummyTokenProvider(audience=self.claims["aud"])
+        # Test first token is set
+        token0 = token_provider.access_token
+        assert token0
+        assert token_provider.decoded_access_token == token_provider._claims
+        # Test token is refreshed and different than before
+        token1 = token_provider.access_token
+        assert token1
+        assert token_provider.decoded_access_token == token_provider._claims
+        assert token0 != token1
+
+
+if __name__ == "__main__":
+    TestAuthTokenValidator().main()
+    TestContxtAuthTokenValidator().main()
+    TestTokenProvider().main()

--- a/tests/services/test_auth.py
+++ b/tests/services/test_auth.py
@@ -1,7 +1,8 @@
 from jose import jwt
 from jose.constants import ALGORITHMS
 
-from contxt.auth.jwt import AuthTokenValidator, ContxtAuthTokenValidator, AuthError
+from contxt.auth.jwt import (AuthError, AuthTokenValidator,
+                             ContxtAuthTokenValidator)
 
 
 def test_auth():


### PR DESCRIPTION
# Why?
* [Contxt SDK: Fix Auth issues](https://ndustrialio.atlassian.net/browse/CTOOLS-16)

# What?
* Create new `TokenProvider` class, whose sole responsibility is to provide a valid unexpired access token (contains the logic to update expired tokens)
* Update `ApiService` to accept new `TokenProvider` 
* Update `AuthService` to inherit from the more recent `ConfiguredApiService`
* Update `BaseAuth`, `MachineAuth`, and `CliAuth` to more clearly follow the flows defined below
* Auth flows
  * Machine (simple case): `BaseAuth` (and `MachineAuth`) are instantiated with `client_id` and `client_secret`. To authenticate to a service, this class provides a method to simply return a `TokenProvider` for the specified audience.
  * CLI (unique case): `CliAuth` requires a 2-step process. First, a Contxt username/password is required to get `access_token_a` from `ndustrial.auth0.com` with an audience of our own `contxtauth.com.` Second, when the user needs to authenticate to a service, `access_token_a` is provided as authentication to `contxtauth.com` to generate `access_token_b` with an audience of the service. So we have to cache `access_token_a` so that the user only needs to login once. But do we also want to cache `access_token_b` for every service the user needs? (we did before, but this refactor does not in order to keep it simple)

# TODO
* Still need to add tests, but I just want to get feedback on this redesign