### PR TITLE
Remove inheritance from CompleteAsset

### DIFF
--- a/contxt/__version__.py
+++ b/contxt/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "contxt-sdk"
 __description__ = "Contxt SDK from ndustrial.io"
 __url__ = "https://github.com/ndustrialio/contxt-sdk-python"
-__version__ = "1.0.0b2"
+__version__ = "1.0.0b3"
 __author__ = "ndustrial.io"
 __author_email__ = "dev@ndustrial.io"
 __license__ = "ISC"

--- a/contxt/models/assets.py
+++ b/contxt/models/assets.py
@@ -450,7 +450,7 @@ class Asset(ApiObject):
         return d
 
 
-class CompleteAsset(ApiObject):
+class CompleteAsset:
     """High-level abstraction of an asset"""
 
     def __init__(self, asset: Asset, asset_type: AssetType):


### PR DESCRIPTION
## Why?
* `CompleteAsset` was erroneously inheriting from an `ABC` but not overloading the abstract methods, preventing instantiation

## What changed?
- [x] Remove `CompleteAsset`'s inheritance from `ApiObject`. The inheritance doesn't make sense here because `CompleteAsset` is not an object fetched from an API, but rather a wrapper containing one.