### PR TITLE
Fix upserting metric values

### DIFF
--- a/contxt/__version__.py
+++ b/contxt/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "contxt-sdk"
 __description__ = "Contxt SDK from ndustrial.io"
 __url__ = "https://github.com/ndustrialio/contxt-sdk-python"
-__version__ = "1.0.0b3"
+__version__ = "1.0.0b4"
 __author__ = "ndustrial.io"
 __author_email__ = "dev@ndustrial.io"
 __license__ = "ISC"

--- a/contxt/models/assets.py
+++ b/contxt/models/assets.py
@@ -1,5 +1,7 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional
+
+from dateutil.relativedelta import relativedelta
 
 from contxt.models import ApiField, ApiObject, Formatters, Parsers
 from contxt.utils import Utils, make_logger
@@ -411,7 +413,7 @@ class Asset(ApiObject):
         updated_at: Optional[datetime] = None,
         parent_id: Optional[str] = None,
         hierarchy_level: Optional[str] = None,
-        attribute_values: Optional[List[MetricValue]] = None,
+        attribute_values: Optional[List[AttributeValue]] = None,
         metric_values: Optional[List[MetricValue]] = None,
         children: Optional[List["Asset"]] = None,
         asset_type: Optional[AssetType] = None,
@@ -497,19 +499,18 @@ class CompleteAsset:
     def _effective_end_date(
         self, effective_start_date: date, time_interval: str
     ) -> date:
-        delta = timedelta()
         if time_interval == TimeIntervals.hourly:
-            delta = timedelta(hours=1) - timedelta(milliseconds=1)
+            delta = relativedelta(hours=1, microseconds=-1)
         elif time_interval == TimeIntervals.daily:
-            delta = timedelta(days=1) - timedelta(milliseconds=1)
+            delta = relativedelta(days=1, microseconds=-1)
         elif time_interval == TimeIntervals.weekly:
-            delta = timedelta(weeks=1) - timedelta(milliseconds=1)
+            delta = relativedelta(weeks=1, microseconds=-1)
         elif time_interval == TimeIntervals.monthly:
-            delta = timedelta(months=1) - timedelta(milliseconds=1)
+            delta = relativedelta(months=1, microseconds=-1)
         elif time_interval == TimeIntervals.yearly:
-            delta = timedelta(years=1) - timedelta(milliseconds=1)
+            delta = relativedelta(years=1, microseconds=-1)
         elif time_interval == TimeIntervals.sparse:
-            pass
+            delta = relativedelta()
         else:
             raise KeyError(f"Unrecognized time interval: {time_interval}")
         return effective_start_date + delta

--- a/contxt/services/assets.py
+++ b/contxt/services/assets.py
@@ -113,7 +113,8 @@ class AssetsService(ConfiguredApi):
         if with_attribute_values and not asset.attribute_values:
             asset.attribute_values = self.get_attribute_values(asset.id)
         if with_metric_values and not asset.metric_values:
-            asset.metric_values = self.get_metric_values(asset.id)
+            # NOTE: this is a paged response, so fetch all records
+            asset.metric_values = [mv for mv in self.get_metric_values(asset.id)]
 
         # Attach asset type
         if not asset.asset_type:


### PR DESCRIPTION
## Why?
* [JIRA](https://lineagelogistics.atlassian.net/browse/NSIGHT-199): Syncing metric values had some bugs

## What changed?
- [x] Replace `datetime.timedelta` with `dateutil.relativedelta.relativedelta`, which is much more powerful
- [x] Fetch all metric values along with an asset for the time being (NOTE: there is not much else we can do here since our client has to handle upserting logic for metric values)
