### PR TITLE
Add retry option to api

### DIFF
--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
+from typing import Dict, FrozenSet, Optional, Tuple
 
 from requests import PreparedRequest, Response, Session
 from requests.adapters import HTTPAdapter
@@ -32,6 +32,10 @@ class ApiRetry(Retry):
         self,
         total: int = 3,
         backoff_factor: float = 0.1,
+        method_whitelist: FrozenSet = frozenset(
+            # NOTE: be careful as some of these methods are not idempotent
+            ["DELETE", "GET", "OPTIONS", "POST", "PUT", "TRACE", "HEAD"]
+        ),
         status_forcelist: Tuple[int, ...] = (500, 502, 504),
         raise_on_status: bool = False,
         **kwargs,
@@ -39,6 +43,7 @@ class ApiRetry(Retry):
         super().__init__(
             total=total,
             backoff_factor=backoff_factor,
+            method_whitelist=method_whitelist,
             status_forcelist=status_forcelist,
             raise_on_status=raise_on_status,
             **kwargs,

--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -3,8 +3,10 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
 from requests import PreparedRequest, Response, Session
+from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
 from requests.exceptions import HTTPError
+from urllib3.util.retry import Retry
 
 from contxt.auth import Auth, TokenProvider
 from contxt.utils import make_logger
@@ -25,6 +27,22 @@ class BearerTokenAuth(AuthBase):
         return request
 
 
+class ApiRetry(Retry):
+    def __init__(
+        self,
+        total: int = 3,
+        backoff_factor: float = 0.1,
+        status_forcelist: Tuple[int, ...] = (500, 502, 504),
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            total=total,
+            backoff_factor=backoff_factor,
+            status_forcelist=status_forcelist,
+            **kwargs,
+        )
+
+
 class Api:
     """
     An API with url `base_url`.
@@ -34,13 +52,23 @@ class Api:
     """
 
     def __init__(
-        self, base_url: str, token_provider: Optional[TokenProvider] = None
+        self,
+        base_url: str,
+        token_provider: Optional[TokenProvider] = None,
+        retry: Optional[ApiRetry] = ApiRetry(),
     ) -> None:
         self.base_url = base_url if base_url.endswith("/") else f"{base_url}/"
+
         # Initialize session
         self.session = Session()
         self.session.auth = BearerTokenAuth(token_provider) if token_provider else None
         self.session.hooks = {"response": self._log_response}
+
+        # Attach retry adapter
+        if retry:
+            adapter = HTTPAdapter(max_retries=retry)
+            self.session.mount("http://", adapter)
+            self.session.mount("https://", adapter)
 
     def _url(self, uri: str) -> str:
         return f"{self.base_url}{uri}"

--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -156,13 +156,15 @@ class ConfiguredApi(Api, ABC):
     Overload this class to implement `_envs`.
     """
 
-    def __init__(self, env: str, auth: Optional[Auth] = None) -> None:
+    def __init__(self, env: str, auth: Optional[Auth] = None, **kwargs) -> None:
         # TODO: figure out a cleaner approach to environment selection
         api_env = self._get_env(env)
         self.env = env
         self.client_id = api_env.client_id
         token_provider = auth.get_token_provider(self.client_id) if auth else None
-        super().__init__(base_url=api_env.base_url, token_provider=token_provider)
+        super().__init__(
+            base_url=api_env.base_url, token_provider=token_provider, **kwargs
+        )
 
     @classmethod
     def _get_env(cls, name: str) -> ApiEnvironment:

--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -33,12 +33,14 @@ class ApiRetry(Retry):
         total: int = 3,
         backoff_factor: float = 0.1,
         status_forcelist: Tuple[int, ...] = (500, 502, 504),
+        raise_on_status: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(
             total=total,
             backoff_factor=backoff_factor,
             status_forcelist=status_forcelist,
+            raise_on_status=raise_on_status,
             **kwargs,
         )
 

--- a/contxt/services/assets.py
+++ b/contxt/services/assets.py
@@ -42,8 +42,9 @@ class AssetsService(ConfiguredApi):
         env: str = "production",
         load_types: bool = True,
         types_to_fully_load: Optional[List[str]] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(env=env, auth=auth)
+        super().__init__(env=env, auth=auth, **kwargs)
         # TODO: handle multiple orgs
         self.organization_id = organization_id
         self.types = {}

--- a/contxt/services/auth.py
+++ b/contxt/services/auth.py
@@ -19,8 +19,8 @@ class AuthService(ConfiguredApi):
         ),
     )
 
-    def __init__(self, env: str = "production"):
-        super().__init__(env=env)
+    def __init__(self, env: str = "production", **kwargs):
+        super().__init__(env=env, **kwargs)
 
     def get_jwks(self) -> Dict:
         return self.get(".well-known/jwks.json")

--- a/contxt/services/bus.py
+++ b/contxt/services/bus.py
@@ -27,9 +27,9 @@ class MessageBusService(ConfiguredApi):
     )
 
     def __init__(
-        self, auth: Auth, organization_id: str, env: str = "production"
+        self, auth: Auth, organization_id: str, env: str = "production", **kwargs
     ) -> None:
-        super().__init__(env=env, auth=auth)
+        super().__init__(env=env, auth=auth, **kwargs)
         self.organization_id = organization_id
 
     def _channels_url(self, service_id: str) -> str:

--- a/contxt/services/contxt.py
+++ b/contxt/services/contxt.py
@@ -34,8 +34,8 @@ class ContxtService(ConfiguredApi):
         # ),
     )
 
-    def __init__(self, auth: Auth, env: str = "production") -> None:
-        super().__init__(env=env, auth=auth)
+    def __init__(self, auth: Auth, env: str = "production", **kwargs) -> None:
+        super().__init__(env=env, auth=auth, **kwargs)
 
     def get_organizations(self) -> List[Organization]:
         logger.debug("Fetching organizations")

--- a/contxt/services/ems.py
+++ b/contxt/services/ems.py
@@ -30,8 +30,8 @@ class EmsService(ConfiguredApi):
         ),
     )
 
-    def __init__(self, auth: Auth, env: str = "production"):
-        super().__init__(env=env, auth=auth)
+    def __init__(self, auth: Auth, env: str = "production", **kwargs):
+        super().__init__(env=env, auth=auth, **kwargs)
 
     def get_facility(self, id: int) -> Facility:
         return Facility.from_api(self.get(f"facilities/{id}"))

--- a/contxt/services/events.py
+++ b/contxt/services/events.py
@@ -27,8 +27,8 @@ class EventsService(ConfiguredApi):
         ),
     )
 
-    def __init__(self, auth: Auth, env: str = "production"):
-        super().__init__(env=env, auth=auth)
+    def __init__(self, auth: Auth, env: str = "production", **kwargs):
+        super().__init__(env=env, auth=auth, **kwargs)
 
     def set_human_readable_parameters(self, event_definition: EventDefinition) -> None:
         statement = ""

--- a/contxt/services/facilities.py
+++ b/contxt/services/facilities.py
@@ -18,8 +18,8 @@ class FacilitiesService(ConfiguredApi):
 
     _envs = AssetsService._envs
 
-    def __init__(self, auth: Auth, env: str = "production"):
-        super().__init__(env=env, auth=auth)
+    def __init__(self, auth: Auth, env: str = "production", **kwargs):
+        super().__init__(env=env, auth=auth, **kwargs)
 
     def get_facilities(self, organization_id: Optional[str] = None) -> List[Facility]:
         logger.debug(f"Fetching facilities for organization {organization_id}")

--- a/contxt/services/iot.py
+++ b/contxt/services/iot.py
@@ -32,8 +32,8 @@ class IotService(ConfiguredApi):
         ),
     )
 
-    def __init__(self, auth: Auth, env: str = "production"):
-        super().__init__(env=env, auth=auth)
+    def __init__(self, auth: Auth, env: str = "production", **kwargs):
+        super().__init__(env=env, auth=auth, **kwargs)
 
     def get_feed_with_id(self, id: int) -> Feed:
         """Get feed with id `id`"""

--- a/contxt/services/ngest.py
+++ b/contxt/services/ngest.py
@@ -23,8 +23,8 @@ class NgestService(ConfiguredApi):
         ),
     )
 
-    def __init__(self, env: str = "production"):
-        super().__init__(env=env)
+    def __init__(self, env: str = "production", **kwargs):
+        super().__init__(env=env, **kwargs)
 
     @staticmethod
     def specialize(feed_key: str, feed_token: str) -> "SpecializedNgestService":

--- a/tests/integration/test_base_api.py
+++ b/tests/integration/test_base_api.py
@@ -9,7 +9,7 @@ from contxt.services.api import Api, ApiRetry
 class TestBaseApi:
     def test_retries(self):
         retry = ApiRetry()
-        api = Api("http://httpbin.org", retry=retry)
+        api = Api("https://httpbin.org", retry=retry)
         t0 = time()
         with pytest.raises(RetryError):
             api.get("status/500")
@@ -17,7 +17,7 @@ class TestBaseApi:
         assert t >= sum(retry.backoff_factor * (2 ** n) for n in range(retry.total))
 
     def test_without_retires(self):
-        api = Api("http://httpbin.org", retry=None)
+        api = Api("https://httpbin.org", retry=None)
         with pytest.raises(HTTPError) as e:
             api.get("status/500")
             assert e.status == 501

--- a/tests/integration/test_base_api.py
+++ b/tests/integration/test_base_api.py
@@ -11,20 +11,13 @@ class TestBaseApi:
         retry = ApiRetry()
         api = Api("http://httpbin.org", retry=retry)
         t0 = time()
-        try:
+        with pytest.raises(RetryError):
             api.get("status/500")
-        except RetryError as e:
-            pass
         t = time() - t0
         assert t >= sum(retry.backoff_factor * (2 ** n) for n in range(retry.total))
 
     def test_without_retires(self):
         api = Api("http://httpbin.org", retry=None)
-        try:
+        with pytest.raises(HTTPError) as e:
             api.get("status/500")
-        except HTTPError as e:
-            pass
-
-
-TestBaseApi().test_retries()
-TestBaseApi().test_without_retires()
+            assert e.status == 501

--- a/tests/integration/test_base_api.py
+++ b/tests/integration/test_base_api.py
@@ -1,7 +1,7 @@
 from time import time
 
 import pytest
-from requests.exceptions import HTTPError, RetryError
+from requests.exceptions import HTTPError
 
 from contxt.services.api import Api, ApiRetry
 
@@ -11,13 +11,14 @@ class TestBaseApi:
         retry = ApiRetry()
         api = Api("https://httpbin.org", retry=retry)
         t0 = time()
-        with pytest.raises(RetryError):
+        with pytest.raises(HTTPError) as e:
             api.get("status/500")
         t = time() - t0
+        assert e.value.response.status_code == 500
         assert t >= sum(retry.backoff_factor * (2 ** n) for n in range(retry.total))
 
-    def test_without_retires(self):
+    def test_without_retries(self):
         api = Api("https://httpbin.org", retry=None)
         with pytest.raises(HTTPError) as e:
             api.get("status/500")
-            assert e.status == 501
+        assert e.value.response.status_code == 500

--- a/tests/integration/test_base_api.py
+++ b/tests/integration/test_base_api.py
@@ -1,0 +1,23 @@
+from time import time
+
+import pytest
+from requests.exceptions import HTTPError, RetryError
+
+from contxt.services.api import Api, ApiRetry
+
+
+class TestBaseApi:
+    def test_retries(self):
+        retry = ApiRetry()
+        api = Api("http://httpbin.org", retry=retry)
+        t0 = time()
+        with pytest.raises(RetryError):
+            api.get("status/500")
+        t = time() - t0
+        assert t >= sum(retry.backoff_factor * (2 ** n) for n in range(retry.total))
+
+    def test_without_retires(self):
+        api = Api("http://httpbin.org", retry=None)
+        with pytest.raises(HTTPError) as e:
+            api.get("status/500")
+            assert e.status == 501

--- a/tests/integration/test_base_api.py
+++ b/tests/integration/test_base_api.py
@@ -11,13 +11,20 @@ class TestBaseApi:
         retry = ApiRetry()
         api = Api("http://httpbin.org", retry=retry)
         t0 = time()
-        with pytest.raises(RetryError):
+        try:
             api.get("status/500")
+        except RetryError as e:
+            pass
         t = time() - t0
         assert t >= sum(retry.backoff_factor * (2 ** n) for n in range(retry.total))
 
     def test_without_retires(self):
         api = Api("http://httpbin.org", retry=None)
-        with pytest.raises(HTTPError) as e:
+        try:
             api.get("status/500")
-            assert e.status == 501
+        except HTTPError as e:
+            pass
+
+
+TestBaseApi().test_retries()
+TestBaseApi().test_without_retires()


### PR DESCRIPTION
## Why?
* Enable API retries on certain server errors

## What changed?
- [x] Add `retry` arg to the base `Api` class
