### PR TITLE
Add support for IOT batch endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ test:
 
 version:
 	# Usage: make version v=[major|minor|patch|release|build]
-	poetry run bump2version $(v) --commit --tag && git push && git push --tags
+	poetry run bump2version --commit --tag $(v)
+	git push && git push --tags
 
 clean:
 	rm -rf dist/ build/ *.egg-info

--- a/contxt/services/iot.py
+++ b/contxt/services/iot.py
@@ -246,8 +246,5 @@ class IotService(ConfiguredApi):
 
     def _batch_request(self, requests: BatchRequests) -> BatchResponses:
         prepared_requests = {label: req.to_api() for label, req in requests.items()}
-        responses = self.post("batch", json=prepared_requests)
-        return {
-            label: ObjectMapper.tree_to_object(resp, BatchResponse)
-            for label, resp in responses.items()
-        }
+        resp = self.post("batch", json=prepared_requests)
+        return ObjectMapper.tree_to_object(resp, BatchResponses)

--- a/contxt/services/iot.py
+++ b/contxt/services/iot.py
@@ -1,8 +1,16 @@
+from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
+
+from requests import Request
 
 from contxt.auth import Auth
+from contxt.models import Parsers
 from contxt.models.iot import (
+    BatchRequest,
+    BatchRequests,
+    BatchResponse,
+    BatchResponses,
     Feed,
     Field,
     FieldGrouping,
@@ -12,6 +20,10 @@ from contxt.models.iot import (
 )
 from contxt.services.api import ApiEnvironment, ConfiguredApi
 from contxt.services.pagination import PagedRecords, PagedTimeSeries, PageOptions
+from contxt.utils import make_logger
+from contxt.utils.object_mapper import ObjectMapper
+
+logger = make_logger(__name__)
 
 
 class IotService(ConfiguredApi):
@@ -32,7 +44,7 @@ class IotService(ConfiguredApi):
         ),
     )
 
-    def __init__(self, auth: Auth, env: str = "production", **kwargs):
+    def __init__(self, auth: Auth, env: str = "production", **kwargs) -> None:
         super().__init__(env=env, auth=auth, **kwargs)
 
     def get_feed_with_id(self, id: int) -> Feed:
@@ -99,7 +111,7 @@ class IotService(ConfiguredApi):
         end_time: Optional[datetime] = None,
         per_page: int = 1000,
     ) -> FieldTimeSeries:
-        """Get time series data for field `Field`"""
+        """Get time series data for field `field`"""
         # Manually validate the window choice, since our API does not return a
         # helpful error message
         assert isinstance(window, Window), "window must be of type Window"
@@ -113,6 +125,79 @@ class IotService(ConfiguredApi):
             },
             per_page=per_page,
         )
+
+    def get_time_series_for_fields(
+        self,
+        fields: List[Field],
+        start_time: datetime,
+        window: Window = Window.RAW,
+        end_time: Optional[datetime] = None,
+    ) -> List[FieldTimeSeries]:
+        """Get complete (non-paginated) time series data for each field in `fields`"""
+        # Build requests queue
+        params = {
+            "timeStart": int(start_time.timestamp()),
+            "timeEnd": int(end_time.timestamp()) if end_time else None,
+            "window": window.value,
+            "limit": 5000,
+        }
+        queue: List[Tuple[str, BatchRequest]] = [
+            (
+                f.field_human_name,
+                BatchRequest.from_request(
+                    Request(
+                        method="GET",
+                        url=self._url(
+                            f"outputs/{f.output_id}/fields/{f.field_human_name}/data"
+                        ),
+                        params=params,
+                    )
+                ),
+            )
+            for f in fields
+        ]
+
+        # Make all requests in queue
+        MAX_BATCH_REQUESTS = 200
+        records: Dict[str, Dict[datetime, str]] = defaultdict(dict)
+        while queue:
+            # Make next batch of requests
+            requests = dict(queue[:MAX_BATCH_REQUESTS])
+            del queue[:MAX_BATCH_REQUESTS]
+            logger.info(f"Making {len(requests)} batched requests to IOT API")
+            responses = self._batch_request(requests)
+            any_success = False
+
+            # Process responses
+            for name, resp in responses.items():
+                if resp.ok:
+                    any_success = True
+                    series = {
+                        Parsers.datetime(r["event_time"]): Parsers.unknown(r["value"])
+                        for r in resp.body["records"]
+                    }
+                    records[name].update(series)
+                    # Add request for next page
+                    next_page_url = resp.body["meta"]["next_page_url"]
+                    if next_page_url:
+                        queue.append(
+                            (name, BatchRequest(method="GET", uri=next_page_url))
+                        )
+                else:
+                    # Retry request
+                    logger.warning(
+                        f"Got bad response from IOT API ({resp.body}). Retrying..."
+                    )
+                    queue.append((name, requests[name]))
+
+            if not any_success:
+                raise IOError(f"All {len(requests)} batched requests to IOT API failed")
+
+        fields_by_name = {f.field_human_name: f for f in fields}
+        return [
+            FieldTimeSeries(field=fields_by_name[name], time_series=series)
+            for name, series in records.items()
+        ]
 
     def get_time_series_for_field_grouping(
         self, grouping_id: str, **kwargs
@@ -158,3 +243,11 @@ class IotService(ConfiguredApi):
             options=page_options,
             record_parser=FieldGrouping.from_api,
         )
+
+    def _batch_request(self, requests: BatchRequests) -> BatchResponses:
+        prepared_requests = {label: req.to_api() for label, req in requests.items()}
+        responses = self.post("batch", json=prepared_requests)
+        return {
+            label: ObjectMapper.tree_to_object(resp, BatchResponse)
+            for label, resp in responses.items()
+        }

--- a/contxt/services/iot.py
+++ b/contxt/services/iot.py
@@ -9,7 +9,6 @@ from contxt.models import Parsers
 from contxt.models.iot import (
     BatchRequest,
     BatchRequests,
-    BatchResponse,
     BatchResponses,
     Feed,
     Field,

--- a/tests/integration/test_iot_service.py
+++ b/tests/integration/test_iot_service.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from pytz import UTC
 
 from contxt.auth.cli import CliAuth
-from contxt.models.iot import Field, UnprovisionedField
+from contxt.models.iot import Field, FieldTimeSeries, UnprovisionedField
 from contxt.services import IotService
 from tests.static.data import TestField
 
@@ -45,6 +45,16 @@ class TestIotService:
         # assert field_data.output_id == TestField.output_id
         # assert field_data.time_series
         # assert min(field_data.time_series.keys()) >= start_time
+
+    def test_get_time_series_for_fields(self):
+        fields = self.service.get_fields_for_feed(TestField.feed_id)[:2]
+        start_time = datetime.now(UTC) - timedelta(days=7)
+        fields_data = self.service.get_time_series_for_fields(
+            fields=fields, start_time=start_time
+        )
+        assert fields_data
+        assert len(fields_data) == len(fields)
+        assert all(isinstance(d, FieldTimeSeries) for d in fields_data)
 
     def test_get_time_series_for_field_grouping(self):
         pass


### PR DESCRIPTION
## Why?
* Support for making batched requests to IOT API

## What changed?
- [x] Add endpoint and models for IOT batched request
- [x] Add `IotService.get_time_series_for_fields` method to batch time series requests
- [x] Add simple test case
