### PR TITLE
Slug hack for now

### DIFF
--- a/contxt/services/contxt.py
+++ b/contxt/services/contxt.py
@@ -53,7 +53,7 @@ class ContxtService(ConfiguredApi):
     def create_organization(self, organization: Organization) -> Organization:
         data = organization.post()
         logger.debug(f"Creating organization with {data}")
-        resp = self.post("organizations", data=data)
+        resp = self.post("organizations", data={"name": data['name'], "slug": data['name']})
         return Organization.from_api(resp)
 
     def add_user_to_organization(


### PR DESCRIPTION
## Why?
* Creating a new Org in contxt was broken using the CLI commands

## What changed?
- [x] Updated the contxt org service to take the name of the org and use that as the slug as a hack to allow the CLI to still perform adding a new organization

## TODO
- The API for contxt to add a new org needs to be update/refactored to now require a slug or auto generate one if the user of the API does not specify one.
