### PR TITLE
Use dataclass for models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 * Removed unnecessary dependencies, `tzlocal` and `argcomplete`
+* Update all models to use dataclasses ([#57](https://github.com/ndustrialio/contxt-sdk-python/pull/57))
 
 ### Fixed
 * API call for `ContxtService.create_organization` now sends new `slug` parameter ([#54](https://github.com/ndustrialio/contxt-sdk-python/pull/54))

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ release: ## Release new version [usage: v=rule]
 	git commit pyproject.toml CHANGELOG.md -m "Bump version to $(VERSION)" && git tag "v$(VERSION)"
 	git push && git push --tags
 	# Publish to pypi
-	poetry publish --build --username ndustrial.io
+	poetry publish --build

--- a/contxt/models/assets.py
+++ b/contxt/models/assets.py
@@ -1,5 +1,6 @@
+from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from dateutil.relativedelta import relativedelta
 
@@ -30,8 +31,9 @@ class DataTypes:
     string = "string"
 
 
+@dataclass
 class Attribute(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("asset_type_id", creatable=True),
         ApiField("label", creatable=True, updatable=True),
@@ -46,42 +48,27 @@ class Attribute(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        asset_type_id: str,
-        label: str,
-        description: str,
-        units: str,
-        organization_id: str,
-        data_type: str,
-        is_required: bool,
-        id: Optional[str] = None,
-        global_asset_attribute_parent_id: Optional[str] = None,
-        is_global: Optional[bool] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.asset_type_id = asset_type_id
-        self.label = label
-        self.description = description
-        self.units = units
-        self.organization_id = organization_id
-        self.data_type = data_type
-        self.is_required = is_required
-        self.global_asset_attribute_parent_id = global_asset_attribute_parent_id
-        self.is_global = is_global
-        self.created_at = created_at
-        self.updated_at = updated_at
+    asset_type_id: str
+    label: str
+    description: str
+    units: str
+    organization_id: str
+    data_type: str
+    is_required: bool
+    id: Optional[str] = None
+    global_asset_attribute_parent_id: Optional[str] = None
+    is_global: Optional[bool] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
     @property
     def normalized_label(self) -> str:
         return Formatters.normalize_label(self.label)
 
 
+@dataclass
 class AttributeValue(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("asset_id"),
         ApiField("asset_attribute_id", attr_key="attribute_id", creatable=True),
@@ -94,28 +81,15 @@ class AttributeValue(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        asset_id: str,
-        attribute_id: str,
-        notes: str,
-        value: Any,
-        id: Optional[str] = None,
-        attribute: Optional[Attribute] = None,
-        effective_date: Optional[datetime] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.asset_id = asset_id
-        self.attribute_id = attribute_id
-        self.attribute = attribute
-        self.effective_date = effective_date or date.today()
-        self.notes = notes
-        self.value = value
-        self.created_at = created_at
-        self.updated_at = updated_at
+    asset_id: str
+    attribute_id: str
+    notes: str
+    value: Any
+    id: Optional[str] = None
+    attribute: Optional[Attribute] = None
+    effective_date: date = field(default_factory=date.today)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
     def upsert(self) -> Dict:
         # HACK: handle special case of upserting attribute_values
@@ -124,9 +98,9 @@ class AttributeValue(ApiObject):
         return {**self.put(), "id": self.id, "asset_attribute_id": self.attribute_id}
 
 
-# TODO: need to fix global metric for POST
+@dataclass
 class Metric(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("asset_type_id"),
         ApiField("label", creatable=True, updatable=True),
@@ -141,41 +115,27 @@ class Metric(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        asset_type_id: str,
-        label: str,
-        description: str,
-        organization_id: str,
-        time_interval: str,
-        units: str,
-        id: Optional[str] = None,
-        global_asset_metric_parent_id: Optional[str] = None,
-        is_global: Optional[bool] = None,
-        is_calculated: Optional[bool] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.asset_type_id = asset_type_id
-        self.label = label
-        self.description = description
-        self.units = units
-        self.organization_id = organization_id
-        self.time_interval = time_interval
-        self.global_asset_metric_parent_id = global_asset_metric_parent_id
-        self.is_global = is_global
-        self.created_at = created_at
-        self.updated_at = updated_at
+    asset_type_id: str
+    label: str
+    description: str
+    organization_id: str
+    time_interval: str
+    units: str
+    id: Optional[str] = None
+    global_asset_metric_parent_id: Optional[str] = None
+    is_global: Optional[bool] = None
+    is_calculated: Optional[bool] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
     @property
     def normalized_label(self) -> str:
         return Formatters.normalize_label(self.label)
 
 
+@dataclass
 class MetricValue(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("asset_id"),
         ApiField(
@@ -200,34 +160,21 @@ class MetricValue(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        asset_id: str,
-        asset_metric_id: str,
-        effective_start_date: datetime,
-        effective_end_date: datetime,
-        notes: str,
-        value: str,
-        id: Optional[str] = None,
-        asset: Optional["Asset"] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.asset_id = asset_id
-        self.asset_metric_id = asset_metric_id
-        self.effective_start_date = effective_start_date
-        self.effective_end_date = effective_end_date
-        self.notes = notes
-        self.value = value
-        self.created_at = created_at
-        self.updated_at = updated_at
-        self.asset = asset
+    asset_id: str
+    asset_metric_id: str
+    effective_start_date: datetime
+    effective_end_date: datetime
+    notes: str
+    value: str
+    id: Optional[str] = None
+    asset: Optional["Asset"] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
+@dataclass
 class AssetType(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("label", creatable=True),
         ApiField("description", creatable=True, updatable=True),
@@ -248,36 +195,24 @@ class AssetType(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        label: str,
-        description: str,
-        organization_id: str,
-        id: Optional[str] = None,
-        is_global: Optional[bool] = None,
-        global_asset_type_parent_id: Optional[str] = None,
-        parent_id: Optional[str] = None,
-        hierarchy_level: Optional[int] = None,
-        attributes: Optional[List[Attribute]] = None,
-        metrics: Optional[List[Metric]] = None,
-        children: Optional[List["AssetType"]] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.label = label
-        self.description = description
-        self.organization_id = organization_id
-        self.parent_id = parent_id
-        self.hierarchy_level = hierarchy_level
-        self.global_asset_type_parent_id = global_asset_type_parent_id
-        self.is_global = is_global
-        self._attributes = attributes or []
-        self._metrics = metrics or []
-        self._children = children or []
-        self.created_at = created_at
-        self.updated_at = updated_at
+    label: str
+    description: str
+    organization_id: str
+    id: Optional[str] = None
+    is_global: Optional[bool] = None
+    global_asset_type_parent_id: Optional[str] = None
+    parent_id: Optional[str] = None
+    hierarchy_level: Optional[int] = None
+    attributes: InitVar[List[Attribute]] = field(default_factory=list)
+    metrics: InitVar[List[Metric]] = field(default_factory=list)
+    children: InitVar[List["AssetType"]] = field(default_factory=list)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    def __post_init__(self, attributes, metrics, children) -> None:
+        self._attributes = attributes
+        self._metrics = metrics
+        self._children = children
 
     @property
     def normalized_label(self) -> str:
@@ -376,8 +311,9 @@ class AssetType(ApiObject):
         return self._children_by_label[child_label]
 
 
+@dataclass
 class Asset(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("asset_type_id", creatable=True),
         ApiField("label", creatable=True),
@@ -402,36 +338,19 @@ class Asset(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        asset_type_id: str,
-        label: str,
-        description: str,
-        organization_id: str,
-        id: Optional[str] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-        parent_id: Optional[str] = None,
-        hierarchy_level: Optional[str] = None,
-        attribute_values: Optional[List[AttributeValue]] = None,
-        metric_values: Optional[List[MetricValue]] = None,
-        children: Optional[List["Asset"]] = None,
-        asset_type: Optional[AssetType] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.asset_type_id = asset_type_id
-        self.asset_type = asset_type
-        self.label = label
-        self.description = description
-        self.organization_id = organization_id
-        self.parent_id = parent_id
-        self.attribute_values = attribute_values or []
-        self.metric_values = metric_values or []
-        self.hierarchy_level = hierarchy_level
-        self.children = children or []
-        self.created_at = created_at
-        self.updated_at = updated_at
+    asset_type_id: str
+    label: str
+    description: str
+    organization_id: str
+    id: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    parent_id: Optional[str] = None
+    hierarchy_level: Optional[str] = None
+    attribute_values: List[AttributeValue] = field(default_factory=list)
+    metric_values: List[MetricValue] = field(default_factory=list)
+    children: List["Asset"] = field(default_factory=list)
+    asset_type: Optional[AssetType] = None
 
     @property
     def normalized_label(self) -> str:

--- a/contxt/models/bus.py
+++ b/contxt/models/bus.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
 from pprint import pformat
-from typing import Any, List, Optional
+from typing import Any, ClassVar, List, Optional
 
 from contxt.models import ApiField, ApiObject
 from contxt.utils.serializer import Serializer
@@ -10,27 +11,25 @@ def pretty_print(obj: Any) -> str:
     return pformat(d, indent=4)
 
 
+@dataclass
 class PublisherStats(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("msgRateIn", attr_key="msg_rate_in"),
         ApiField("producerId", attr_key="producer_id"),
         ApiField("connectedSince", attr_key="connected_since"),
     )
 
-    def __init__(
-        self, msg_rate_in: str, producer_id: str, connected_since: str
-    ) -> None:
-        super().__init__()
-        self.msg_rate_in = msg_rate_in
-        self.producer_id = producer_id
-        self.connected_since = connected_since
+    msg_rate_in: str
+    producer_id: str
+    connected_since: str
 
     def __str__(self) -> str:
         return pretty_print(self)
 
 
+@dataclass
 class ConsumerStats(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("msgRateOut", attr_key="msg_rate_out", data_type=float),
         ApiField("msgRateRedeliver", attr_key="msg_rate_redeliver", data_type=float),
         ApiField("unackedMessages", attr_key="unacked_messages", data_type=int),
@@ -42,27 +41,19 @@ class ConsumerStats(ApiObject):
         ApiField("connectedSince", attr_key="connected_since"),
     )
 
-    def __init__(
-        self,
-        msg_rate_out: float,
-        msg_rate_redeliver: float,
-        unacked_messages: int,
-        blocked_consumer_on_unacked_msgs: bool,
-        connected_since: str,
-    ) -> None:
-        super().__init__()
-        self.msg_rate_out = msg_rate_out
-        self.msg_rate_redeliver = msg_rate_redeliver
-        self.unacked_messages = unacked_messages
-        self.blocked_consumer_on_unacked_msgs = blocked_consumer_on_unacked_msgs
-        self.connected_since = connected_since
+    msg_rate_out: float
+    msg_rate_redeliver: float
+    unacked_messages: int
+    blocked_consumer_on_unacked_msgs: bool
+    connected_since: str
 
     def __str__(self) -> str:
         return pretty_print(self)
 
 
+@dataclass
 class SubscriberStats(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("name", optional=True),
         ApiField("msgRateOut", attr_key="msg_rate_out", data_type=float),
         ApiField("msgRateRedeliver", attr_key="msg_rate_redeliver", data_type=float),
@@ -76,52 +67,39 @@ class SubscriberStats(ApiObject):
         ApiField("consumers", data_type=ConsumerStats),
     )
 
-    def __init__(
-        self,
-        msg_rate_out: float,
-        msg_rate_redeliver: float,
-        msg_backlog: int,
-        blocked_subscription_on_unacked_msgs: bool,
-        unacked_messages: int,
-        consumers: List[ConsumerStats],
-        name: Optional[str] = None,
-    ) -> None:
-        super().__init__()
-        self.name = name
-        self.msg_rate_out = msg_rate_out
-        self.msg_rate_redeliver = msg_rate_redeliver
-        self.msg_backlog = msg_backlog
-        self.blocked_subscription_on_unacked_msgs = blocked_subscription_on_unacked_msgs
-        self.unacked_messages = unacked_messages
-        self.consumers = consumers
+    msg_rate_out: float
+    msg_rate_redeliver: float
+    msg_backlog: int
+    blocked_subscription_on_unacked_msgs: bool
+    unacked_messages: int
+    consumers: List[ConsumerStats]
+    name: Optional[str] = None
 
     def __str__(self) -> str:
         return pretty_print(self)
 
 
+@dataclass
 class Channel(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("name"),
         ApiField("organization_id"),
         ApiField("service_id"),
     )
 
-    def __init__(
-        self, id: str, name: str, organization_id: str, service_id: str
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.organization_id = organization_id
-        self.service_id = service_id
+    id: str
+    name: str
+    organization_id: str
+    service_id: str
 
     def __str__(self) -> str:
         return pretty_print(self)
 
 
+@dataclass
 class ChannelStats(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("msgRateIn", attr_key="msg_rate_in", data_type=float),
         ApiField("msgRateOut", attr_key="msg_rate_out", data_type=float),
         ApiField("msgThroughputIn", attr_key="msg_throughput_in", data_type=float),
@@ -139,30 +117,16 @@ class ChannelStats(ApiObject):
         ),
     )
 
-    def __init__(
-        self,
-        msg_rate_in: float,
-        msg_rate_out: float,
-        msg_throughput_in: float,
-        msg_throughput_out: float,
-        avg_msg_size: float,
-        storage_size: float,
-        replication: dict,
-        deduplication_status: str,
-        publishers: List[PublisherStats],
-        subscriptions: List[SubscriberStats],
-    ) -> None:
-        super().__init__()
-        self.msg_rate_in = msg_rate_in
-        self.msg_rate_out = msg_rate_out
-        self.msg_throughput_in = msg_throughput_in
-        self.msg_throughput_out = msg_throughput_out
-        self.avg_msg_size = avg_msg_size
-        self.storage_size = storage_size
-        self.replication = replication
-        self.deduplication_status = deduplication_status
-        self.publishers = publishers
-        self.subscriptions = subscriptions
+    msg_rate_in: float
+    msg_rate_out: float
+    msg_throughput_in: float
+    msg_throughput_out: float
+    avg_msg_size: float
+    storage_size: float
+    replication: dict
+    deduplication_status: str
+    publishers: List[PublisherStats]
+    subscriptions: List[SubscriberStats]
 
     def __str__(self) -> str:
         return pretty_print(self)

--- a/contxt/models/contxt.py
+++ b/contxt/models/contxt.py
@@ -1,12 +1,14 @@
+from dataclasses import dataclass
 from datetime import datetime
 from json import loads
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 
 from contxt.models import ApiField, ApiObject, Parsers
 
 
+@dataclass
 class ConfigValue(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("key"),
         ApiField("value"),
@@ -17,26 +19,17 @@ class ConfigValue(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        id: str,
-        key: str,
-        value: str,
-        type: str,
-        configuration_id: str,
-        is_hidden: bool,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.key = key
-        self.value = self._init_value(value, type)
-        self.type = type
-        self.configuration_id = configuration_id
-        self.is_hidden = is_hidden
-        self.created_at = created_at
-        self.updated_at = updated_at
+    id: str
+    key: str
+    value: str
+    type: str
+    configuration_id: str
+    is_hidden: bool
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        self.value = self._init_value(self.value, self.type)
 
     def _init_value(self, value, type):
         if type == "integer":
@@ -47,8 +40,9 @@ class ConfigValue(ApiObject):
             return str(value)
 
 
+@dataclass
 class Config(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("name"),
         ApiField("description"),
@@ -60,28 +54,18 @@ class Config(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        id: str,
-        name: str,
-        description: str,
-        environment_id: str,
-        config_values: List[ConfigValue],
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.description = description
-        self.environment_id = environment_id
-        self.config_values = config_values
-        self.created_at = created_at
-        self.updated_at = updated_at
+    id: str
+    name: str
+    description: str
+    environment_id: str
+    config_values: List[ConfigValue]
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
+@dataclass
 class OrganizationUser(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("user_id"),
         ApiField("organization_id"),
@@ -90,27 +74,17 @@ class OrganizationUser(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        id: str,
-        user_id: str,
-        organization_id: str,
-        is_primary: bool,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.user_id = user_id
-        self.organization_id = organization_id
-        self.is_primary = is_primary
-        self.created_at = created_at
-        self.updated_at = updated_at
+    id: str
+    user_id: str
+    organization_id: str
+    is_primary: bool
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
-# TODO: hide organization_user, updated_at
+@dataclass
 class Organization(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("name", creatable=True),
         ApiField("legacy_organization_id", attr_key="legacy_id", optional=True),
@@ -124,26 +98,17 @@ class Organization(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        name: str,
-        id: Optional[str] = None,
-        legacy_id: Optional[int] = None,
-        organization_user: Optional[OrganizationUser] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.legacy_id = legacy_id
-        self.name = name
-        self.organization_user = organization_user
-        self.created_at = created_at
-        self.updated_at = updated_at
+    name: str
+    id: Optional[str] = None
+    legacy_id: Optional[int] = None
+    organization_user: Optional[OrganizationUser] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
+@dataclass
 class UserRole(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("user_id"),
         ApiField("role_id"),
@@ -152,27 +117,17 @@ class UserRole(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        user_id: str,
-        role_id: str,
-        mapped_from_external_group: bool,
-        id: Optional[str] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.user_id = user_id
-        self.role_id = role_id
-        self.mapped_from_external_group = mapped_from_external_group
-        self.created_at = created_at
-        self.updated_at = updated_at
+    user_id: str
+    role_id: str
+    mapped_from_external_group: bool
+    id: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
-# TODO: hide created_at, updated_at
+@dataclass
 class Role(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("name"),
         ApiField("description"),
@@ -182,30 +137,18 @@ class Role(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        name: str,
-        description: str,
-        organization_id: str,
-        user_role: UserRole,
-        id: Optional[str] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.description = description
-        self.organization_id = organization_id
-        self.user_role = user_role
-        self.created_at = created_at
-        self.updated_at = updated_at
+    name: str
+    description: str
+    organization_id: str
+    user_role: UserRole
+    id: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
-# TODO: hide email, phone_number, is_superuser, roles (transform to list of
-# role.name), organizations, created_at, updated_at
+@dataclass
 class User(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("first_name"),
         ApiField("last_name"),
@@ -219,29 +162,14 @@ class User(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        first_name: str,
-        last_name: str,
-        email: str,
-        phone_number: str,
-        is_activated: bool,
-        is_superuser: bool,
-        roles: List[Role],
-        organizations: List[Organization],
-        id: Optional[str] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.first_name = first_name
-        self.last_name = last_name
-        self.email = email
-        self.phone_number = phone_number
-        self.is_activated = is_activated
-        self.is_superuser = is_superuser
-        self.roles = roles
-        self.organizations = organizations
-        self.created_at = created_at
-        self.updated_at = updated_at
+    first_name: str
+    last_name: str
+    email: str
+    phone_number: str
+    is_activated: bool
+    is_superuser: bool
+    roles: List[Role]
+    organizations: List[Organization]
+    id: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None

--- a/contxt/models/ems.py
+++ b/contxt/models/ems.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 
 from contxt.models import ApiField, ApiObject, Parsers
 from contxt.models.events import Event
@@ -14,8 +15,9 @@ class ResourceType(Enum):
     WATER = "water"
 
 
+@dataclass
 class MainService(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id", data_type=int),
         ApiField("facility_id", data_type=int),
         ApiField("name"),
@@ -28,34 +30,21 @@ class MainService(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        id: int,
-        facility_id: int,
-        name: str,
-        resource_type: ResourceType,
-        demand_field_id: int,
-        usage_field_id: int,
-        demand_field: Field,
-        usage_field: Field,
-        created_at: datetime,
-        updated_at: datetime,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.facility_id = facility_id
-        self.name = name
-        self.resource_type = resource_type
-        self.demand_field_id = demand_field_id
-        self.usage_field_id = usage_field_id
-        self.demand_field = demand_field
-        self.usage_field = demand_field
-        self.created_at = created_at
-        self.updated_at = updated_at
+    id: int
+    facility_id: int
+    name: str
+    resource_type: ResourceType
+    demand_field_id: int
+    usage_field_id: int
+    demand_field: Field
+    usage_field: Field
+    created_at: datetime
+    updated_at: datetime
 
 
+@dataclass
 class Facility(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id", data_type=int),
         ApiField("name"),
         ApiField("asset_id"),
@@ -66,92 +55,70 @@ class Facility(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        id: int,
-        name: str,
-        asset_id: str,
-        organization_id: str,
-        baseline: dict,
-        main_services: List[MainService],
-        created_at: datetime,
-        updated_at: datetime,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.asset_id = asset_id
-        self.organization_id = organization_id
-        self.baseline = baseline
-        self.main_services = main_services
-        self.created_at = created_at
-        self.updated_at = updated_at
+    id: int
+    name: str
+    asset_id: str
+    organization_id: str
+    baseline: dict
+    main_services: List[MainService]
+    created_at: datetime
+    updated_at: datetime
 
 
-class UtilitySpendPeriod(ApiObject):
-    _api_fields = (
+@dataclass
+class UtilityPeriod(ApiObject):
+    _api_fields: ClassVar = (
         ApiField("date"),
         ApiField("value"),
         ApiField("pro_forma_date", optional=True),
     )
 
-    def __init__(
-        self, date: str, value: str, pro_forma_date: Optional[str] = None
-    ) -> None:
-        super().__init__()
-        self.date = date
-        self.value = value
-        self.pro_forma_date = pro_forma_date
+    date: str
+    value: str
+    pro_forma_date: Optional[str] = None
 
 
+UtilitySpendPeriod = UtilityPeriod
+UtilityUsagePeriod = UtilityPeriod
+
+
+@dataclass
 class UtilitySpend(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("type"),
         ApiField("currency"),
         ApiField("values", data_type=UtilitySpendPeriod),
     )
 
-    def __init__(
-        self, type: str, currency: str, values: List[UtilitySpendPeriod]
-    ) -> None:
-        super().__init__()
-        self.type = type
-        self.currency = currency
-        self.periods = values
+    type: str
+    currency: str
+    values: List[UtilitySpendPeriod]
+
+    @property
+    def periods(self):
+        return self.values
 
 
-class UtilityUsagePeriod(ApiObject):
-    _api_fields = (
-        ApiField("date"),
-        ApiField("value"),
-        ApiField("pro_forma_date", optional=True),
-    )
-
-    def __init__(
-        self, date: str, value: str, pro_forma_date: Optional[str] = None
-    ) -> None:
-        super().__init__()
-        self.date = date
-        self.value = value
-        self.pro_forma_date = pro_forma_date
-
-
+@dataclass
 class UtilityUsage(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("type"),
         ApiField("unit"),
         ApiField("values", data_type=UtilityUsagePeriod),
     )
 
-    def __init__(self, type: str, unit: str, values: Dict) -> None:
-        super().__init__()
-        self.type = type
-        self.unit = unit
-        self.periods = values
+    type: str
+    unit: str
+    values: Dict
+
+    @property
+    def periods(self):
+        return self.values
 
 
+@dataclass
 class UtilityContractReminder(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("utility_contract_id", data_type=int),
         ApiField("user_id", data_type=str),
         ApiField("user_event_subscription_id", data_type=str),
@@ -159,24 +126,16 @@ class UtilityContractReminder(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        utility_contract_id: int,
-        user_id: str,
-        user_event_subscription_id: str,
-        created_at: datetime,
-        updated_at: datetime,
-    ):
-        super().__init__()
-        self.utility_contract_id = utility_contract_id
-        self.user_id = user_id
-        self.user_event_subscription_id = user_event_subscription_id
-        self.created_at = created_at
-        self.updated_at = updated_at
+    utility_contract_id: int
+    user_id: str
+    user_event_subscription_id: str
+    created_at: datetime
+    updated_at: datetime
 
 
+@dataclass
 class UtilityContract(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id", data_type=int),
         ApiField("name"),
         ApiField("facility_id", data_type=int),
@@ -193,35 +152,17 @@ class UtilityContract(ApiObject):
         ApiField("report_event", data_type=Event),
     )
 
-    def __init__(
-        self,
-        id: int,
-        name: str,
-        facility_id: int,
-        status: str,
-        start_date: datetime,
-        end_date: datetime,
-        rate_narrative: str,
-        file_id: str,
-        created_at: datetime,
-        updated_at: datetime,
-        created_by: str,
-        utility_contract_reminders: list,
-        report_event_id: str,
-        report_event: Event,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.facility_id = facility_id
-        self.status = status
-        self.start_date = start_date
-        self.end_date = end_date
-        self.rate_narrative = rate_narrative
-        self.file_id = file_id
-        self.created_at = created_at
-        self.updated_at = updated_at
-        self.created_by = created_by
-        self.utility_contract_reminders = utility_contract_reminders
-        self.report_event_id = report_event_id
-        self.report_event = report_event
+    id: int
+    name: str
+    facility_id: int
+    status: str
+    start_date: datetime
+    end_date: datetime
+    rate_narrative: str
+    file_id: str
+    created_at: datetime
+    updated_at: datetime
+    created_by: str
+    utility_contract_reminders: List[UtilityContractReminder]
+    report_event_id: str
+    report_event: Event

--- a/contxt/models/events.py
+++ b/contxt/models/events.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass
 from datetime import datetime
 from json import loads
-from typing import Optional
+from typing import ClassVar, Optional
 
 from contxt.models import ApiField, ApiObject, Parsers
 from contxt.utils import make_logger
@@ -8,8 +9,9 @@ from contxt.utils import make_logger
 logger = make_logger(__name__)
 
 
+@dataclass
 class EventType(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("name", creatable=True),
         ApiField("slug", creatable=True),
@@ -22,34 +24,21 @@ class EventType(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        name: str,
-        slug: str,
-        description: str,
-        client_id: str,
-        level: int,
-        id: Optional[str] = None,
-        is_ongoing_event: Optional[bool] = None,
-        is_realtime_enabled: Optional[bool] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.slug = slug
-        self.client_id = client_id
-        self.description = description
-        self.level = level
-        self.is_ongoing_event = is_ongoing_event
-        self.is_realtime_enabled = is_realtime_enabled
-        self.created_at = created_at
-        self.updated_at = updated_at
+    name: str
+    slug: str
+    description: str
+    client_id: str
+    level: int
+    id: Optional[str] = None
+    is_ongoing_event: Optional[bool] = None
+    is_realtime_enabled: Optional[bool] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
+@dataclass
 class EventDefinition(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("event_id"),
         ApiField("description"),
@@ -58,28 +47,18 @@ class EventDefinition(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        event_id: str,
-        description: str,
-        parameters: dict,
-        created_at: datetime,
-        updated_at: datetime,
-        id: Optional[str] = None,
-        human_readable_parameters: Optional[str] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.event_id = event_id
-        self.description = description
-        self.parameters = parameters
-        self.human_readable_parameters = human_readable_parameters
-        self.created_at = created_at
-        self.updated_at = updated_at
+    event_id: str
+    description: str
+    parameters: dict
+    created_at: datetime
+    updated_at: datetime
+    id: Optional[str] = None
+    human_readable_parameters: Optional[str] = None
 
 
+@dataclass
 class Owner(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("first_name"),
         ApiField("last_name"),
@@ -89,28 +68,18 @@ class Owner(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        id: str,
-        first_name: str,
-        last_name: str,
-        email: str,
-        is_machine_user: bool,
-        created_at: datetime,
-        updated_at: datetime,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.first_name = first_name
-        self.last_name = last_name
-        self.email = email
-        self.is_machine_user = is_machine_user
-        self.created_at = created_at
-        self.updated_at = updated_at
+    id: str
+    first_name: str
+    last_name: str
+    email: str
+    is_machine_user: bool
+    created_at: datetime
+    updated_at: datetime
 
 
+@dataclass
 class Event(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("name", creatable=True),
         ApiField("event_type_id", creatable=True),
@@ -129,64 +98,40 @@ class Event(ApiObject):
         ApiField("deleted_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        name: str,
-        event_type_id: str,
-        organization_id: str,
-        allow_others_to_trigger: bool,
-        is_public: bool,
-        id: Optional[str] = None,
-        facility_id: Optional[int] = None,
-        owner_id: Optional[str] = None,
-        owner: Optional[Owner] = None,
-        event_type: Optional[EventType] = None,
-        topic_arn: Optional[str] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-        deleted_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.event_type_id = event_type_id
-        self.event_type = event_type
-        self.facility_id = facility_id
-        self.organization_id = organization_id
-        self.owner_id = owner_id
-        self.owner = owner
-        self.topic_arn = topic_arn
-        self.allow_others_to_trigger = allow_others_to_trigger
-        self.is_public = is_public
-        self.created_at = created_at
-        self.updated_at = updated_at
-        self.deleted_at = deleted_at
+    name: str
+    event_type_id: str
+    organization_id: str
+    allow_others_to_trigger: bool
+    is_public: bool
+    id: Optional[str] = None
+    facility_id: Optional[int] = None
+    owner_id: Optional[str] = None
+    owner: Optional[Owner] = None
+    event_type: Optional[EventType] = None
+    topic_arn: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    deleted_at: Optional[datetime] = None
 
 
+@dataclass
 class TriggeredEventData(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("source_id"),
         ApiField("subchain_triggered_event_id"),
         ApiField("trigger_start_at", data_type=Parsers.datetime),
         ApiField("trigger_end_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        source_id: str,
-        subchain_triggered_event_id: str,
-        trigger_start_at: datetime,
-        trigger_end_at: datetime,
-    ) -> None:
-        super().__init__()
-        self.source_id = source_id
-        self.subchain_triggered_event_id = subchain_triggered_event_id
-        self.trigger_start_at = trigger_start_at
-        self.trigger_end_at = trigger_end_at
+    source_id: str
+    subchain_triggered_event_id: str
+    trigger_start_at: datetime
+    trigger_end_at: datetime
 
 
+@dataclass
 class TriggeredEvent(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("event_id", creatable=True),
         ApiField("Event", data_type=Event, attr_key="event"),
@@ -213,31 +158,15 @@ class TriggeredEvent(ApiObject):
         ApiField("deleted_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        event_id: str,
-        trigger_start_at: datetime,
-        id: Optional[str],
-        owner_id: Optional[str] = None,
-        owner: Optional[Owner] = None,
-        event: Optional[Event] = None,
-        is_public: Optional[bool] = None,
-        trigger_end_at: Optional[datetime] = None,
-        data: Optional[dict] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-        deleted_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.event_id = event_id
-        self.event = event
-        self.owner_id = owner_id
-        self.owner = owner
-        self.is_public = is_public
-        self.data = data
-        self.trigger_start_at = trigger_start_at
-        self.trigger_end_at = trigger_end_at
-        self.created_at = created_at
-        self.updated_at = updated_at
-        self.deleted_at = deleted_at
+    event_id: str
+    trigger_start_at: datetime
+    id: Optional[str]
+    owner_id: Optional[str] = None
+    owner: Optional[Owner] = None
+    event: Optional[Event] = None
+    is_public: Optional[bool] = None
+    trigger_end_at: Optional[datetime] = None
+    data: Optional[dict] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    deleted_at: Optional[datetime] = None

--- a/contxt/models/facilities.py
+++ b/contxt/models/facilities.py
@@ -1,9 +1,13 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
 from contxt.models import ApiField, ApiObject, Parsers
 from contxt.models.contxt import Organization
 
 
+@dataclass
 class Facility(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id", data_type=int),
         ApiField("name"),
         ApiField("address1"),
@@ -27,41 +31,20 @@ class Facility(ApiObject):
         ApiField("slug"),
     )
 
-    def __init__(
-        self,
-        id: int,
-        name: str,
-        address1: str,
-        address2: str,
-        city: str,
-        state: str,
-        zip: str,
-        timezone: str,
-        geometry_id: str,
-        asset_id: str,
-        tags: list,
-        organization_id: str,
-        organization: Organization,
-        info: dict,
-        weather_location_id: str,
-        created_at: str,
-        slug: str,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.address1 = address1
-        self.address2 = address2
-        self.city = city
-        self.state = state
-        self.zip = zip
-        self.timezone = timezone
-        self.geometry_id = geometry_id
-        self.asset_id = asset_id
-        self.tags = tags
-        self.organization_id = organization_id
-        self.organization = organization
-        self.weather_location_id = weather_location_id
-        self.info = info
-        self.created_at = created_at
-        self.slug = slug
+    id: int
+    name: str
+    address1: str
+    address2: str
+    city: str
+    state: str
+    zip: str
+    timezone: str
+    geometry_id: str
+    asset_id: str
+    tags: list
+    organization_id: str
+    organization: Organization
+    info: dict
+    weather_location_id: str
+    created_at: str
+    slug: str

--- a/contxt/models/health.py
+++ b/contxt/models/health.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import ClassVar
 
 from pytz import UTC
 
@@ -14,15 +15,12 @@ class HealthStatus(Enum):
     BAD = "unhealthy"
 
 
+@dataclass
 class Health(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("status", data_type=HealthStatus, creatable=True),
         ApiField("timestamp", data_type=Parsers.datetime, creatable=True),
     )
 
-    def __init__(
-        self, status: HealthStatus, timestamp: Optional[datetime] = datetime.now(UTC)
-    ) -> None:
-        super().__init__()
-        self.status = status
-        self.timestamp = timestamp
+    status: HealthStatus
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))

--- a/contxt/models/iot.py
+++ b/contxt/models/iot.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from json import loads
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from requests import Request
 
@@ -23,8 +23,9 @@ class FieldValueType(Enum):
     STRING = "string"
 
 
+@dataclass
 class Field(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id", data_type=int),
         ApiField("field_name", attr_key="name", optional=True),
         ApiField("label", creatable=True, updatable=True),
@@ -60,54 +61,31 @@ class Field(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime, optional=True),
     )
 
-    def __init__(
-        self,
-        label: str,
-        output_id: str,
-        field_descriptor: str,
-        units: str,
-        id: Optional[int] = None,
-        name: Optional[str] = None,
-        field_human_name: Optional[str] = None,
-        feed_key: Optional[str] = None,
-        field_grouping_field: Optional[Dict] = None,
-        value_type: Optional[FieldValueType] = None,
-        scalar: Optional[float] = None,
-        divisor: Optional[float] = None,
-        is_hidden: Optional[bool] = None,
-        is_totalizer: Optional[bool] = None,
-        is_windowed: Optional[bool] = None,
-        is_default: Optional[bool] = None,
-        can_aggregate: Optional[bool] = None,
-        status: Optional[str] = None,
-        created_at: Optional[datetime] = None,
-        updated_at: Optional[datetime] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.label = label
-        self.output_id = output_id
-        self.field_descriptor = field_descriptor
-        self.field_human_name = field_human_name
-        self.scalar = scalar
-        self.divisor = divisor
-        self.value_type = value_type
-        self.feed_key = feed_key
-        self.is_hidden = is_hidden
-        self.is_totalizer = is_totalizer
-        self.is_windowed = is_windowed
-        self.is_default = is_default
-        self.can_aggregate = can_aggregate
-        self.status = status
-        self.units = units
-        self.field_grouping_field = field_grouping_field
-        self.created_at = created_at
-        self.updated_at = updated_at
+    label: str
+    output_id: str
+    field_descriptor: str
+    units: str
+    id: Optional[int] = None
+    name: Optional[str] = None
+    field_human_name: Optional[str] = None
+    feed_key: Optional[str] = None
+    field_grouping_field: Optional[Dict] = None
+    value_type: Optional[FieldValueType] = None
+    scalar: Optional[float] = None
+    divisor: Optional[float] = None
+    is_hidden: Optional[bool] = None
+    is_totalizer: Optional[bool] = None
+    is_windowed: Optional[bool] = None
+    is_default: Optional[bool] = None
+    can_aggregate: Optional[bool] = None
+    status: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
+@dataclass
 class FieldCategory(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("name"),
         ApiField("description"),
@@ -117,28 +95,18 @@ class FieldCategory(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        id: str,
-        name: str,
-        description: str,
-        organization_id: str,
-        parent_category_id: str,
-        created_at: datetime,
-        updated_at: datetime,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.name = name
-        self.description = description
-        self.organization_id = organization_id
-        self.parent_category_id = parent_category_id
-        self.created_at = created_at
-        self.updated_at = updated_at
+    id: str
+    name: str
+    description: str
+    organization_id: str
+    parent_category_id: str
+    created_at: datetime
+    updated_at: datetime
 
 
+@dataclass
 class FieldGrouping(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("label"),
         ApiField("slug"),
@@ -154,49 +122,32 @@ class FieldGrouping(ApiObject):
         ApiField("updated_at", data_type=Parsers.datetime),
     )
 
-    def __init__(
-        self,
-        id: str,
-        label: str,
-        slug: str,
-        description: str,
-        facility_id: int,
-        is_public: bool,
-        owner_id: str,
-        owner: Owner,
-        field_category_id: str,
-        field_category: FieldCategory,
-        fields: List[Field],
-        created_at: datetime,
-        updated_at: datetime,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.label = label
-        self.slug = slug
-        self.description = description
-        self.facility_id = facility_id
-        self.owner_id = owner_id
-        self.is_public = is_public
-        self.field_category_id = field_category_id
-        self.owner = owner
-        self.category = field_category
-        self.fields = fields
-        self.created_at = created_at
-        self.updated_at = updated_at
+    id: str
+    label: str
+    slug: str
+    description: str
+    facility_id: int
+    is_public: bool
+    owner_id: str
+    owner: Owner
+    field_category_id: str
+    field_category: FieldCategory
+    fields: List[Field]
+    created_at: datetime
+    updated_at: datetime
 
 
+@dataclass
 class UnprovisionedField(ApiObject):
-    _api_fields = (ApiField("field_descriptor"), ApiField("assumed_type"))
+    _api_fields: ClassVar = (ApiField("field_descriptor"), ApiField("assumed_type"))
 
-    def __init__(self, field_descriptor: str, assumed_type: str) -> None:
-        super().__init__()
-        self.field_descriptor = field_descriptor
-        self.assumed_type = assumed_type
+    field_descriptor: str
+    assumed_type: str
 
 
+@dataclass
 class Feed(ApiObject):
-    _api_fields = (
+    _api_fields: ClassVar = (
         ApiField("id", data_type=int),
         ApiField("feed_type_id", data_type=int),
         ApiField("down_after"),
@@ -219,50 +170,26 @@ class Feed(ApiObject):
         ApiField("Metrics", attr_key="metrics", data_type=dict, optional=True),
     )
 
-    def __init__(
-        self,
-        id: int,
-        facility_id: int,
-        feed_type_id: int,
-        down_after: str,
-        key: str,
-        timezone: str,
-        token: str,
-        status: str,
-        degraded_threshold: float,
-        critical_threshold: float,
-        status_event_id: str,
-        created_at: datetime,
-        updated_at: datetime,
-        routing_keys: str,
-        is_paused: bool,
-        owner_id: str,
-        feed_type: str,
-        owner: Owner,
-        feed_status: str,
-        metrics: Optional[Dict] = None,
-    ) -> None:
-        super().__init__()
-        self.id = id
-        self.feed_type_id = feed_type_id
-        self.down_after = down_after
-        self.key = key
-        self.facility_id = facility_id
-        self.timezone = timezone
-        self.token = token
-        self.status = status
-        self.degraded_threshold = degraded_threshold
-        self.critical_threshold = critical_threshold
-        self.status_event_id = status_event_id
-        self.created_at = created_at
-        self.updated_at = updated_at
-        self.routing_keys = routing_keys
-        self.is_paused = is_paused
-        self.owner_id = owner_id
-        self.feed_type = feed_type
-        self.owner = owner
-        self.feed_status = feed_status
-        self.metrics = metrics
+    id: int
+    facility_id: int
+    feed_type_id: int
+    down_after: str
+    key: str
+    timezone: str
+    token: str
+    status: str
+    degraded_threshold: float
+    critical_threshold: float
+    status_event_id: str
+    created_at: datetime
+    updated_at: datetime
+    routing_keys: str
+    is_paused: bool
+    owner_id: str
+    feed_type: str
+    owner: Owner
+    feed_status: str
+    metrics: Optional[Dict] = None
 
 
 @dataclass

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,16 +7,9 @@ python-versions = "*"
 version = "1.4.3"
 
 [[package]]
-category = "main"
-description = "Bash tab completion for argparse"
-name = "argcomplete"
-optional = false
-python-versions = "*"
-version = "1.10.0"
-
-[[package]]
 category = "dev"
 description = "Atomic file writes."
+marker = "sys_platform == \"win32\""
 name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -28,7 +21,13 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.1.0"
+version = "19.3.0"
+
+[package.extras]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
+docs = ["sphinx", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
 category = "main"
@@ -41,27 +40,28 @@ version = "3.9.1"
 [package.dependencies]
 requests = "*"
 
+[package.extras]
+test = ["mock"]
+
 [[package]]
 category = "dev"
 description = "The uncompromising code formatter."
 name = "black"
 optional = false
 python-versions = ">=3.6"
-version = "19.3b0"
+version = "19.10b0"
 
 [package.dependencies]
 appdirs = "*"
 attrs = ">=18.1.0"
 click = ">=6.5"
+pathspec = ">=0.6,<1"
+regex = "*"
 toml = ">=0.9.4"
+typed-ast = ">=1.4.0"
 
-[[package]]
-category = "dev"
-description = "Version-bump your software with a single command!"
-name = "bump2version"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.5.11"
+[package.extras]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 category = "main"
@@ -69,7 +69,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2019.9.11"
+version = "2019.11.28"
 
 [[package]]
 category = "main"
@@ -93,8 +93,8 @@ description = "Cross-platform colored terminal text."
 marker = "sys_platform == \"win32\""
 name = "colorama"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.4.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
 
 [[package]]
 category = "main"
@@ -110,8 +110,11 @@ category = "main"
 description = "ECDSA cryptographic signature library (pure python)"
 name = "ecdsa"
 optional = true
-python-versions = "*"
-version = "0.13.2"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.14.1"
+
+[package.dependencies]
+six = "*"
 
 [[package]]
 category = "dev"
@@ -127,7 +130,7 @@ description = "the modular source code checker: pep8, pyflakes and co"
 name = "flake8"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.7.8"
+version = "3.7.9"
 
 [package.dependencies]
 entrypoints = ">=0.3.0,<0.4.0"
@@ -141,7 +144,7 @@ description = "Clean single-source support for Python 3 and 2"
 name = "future"
 optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "0.17.1"
+version = "0.18.2"
 
 [[package]]
 category = "main"
@@ -157,11 +160,15 @@ description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
-python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
-version = "0.23"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.3.0"
 
 [package.dependencies]
 zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "importlib-resources"]
 
 [[package]]
 category = "dev"
@@ -170,6 +177,12 @@ name = "isort"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "4.3.21"
+
+[package.extras]
+pipfile = ["pipreqs", "requirementslib"]
+pyproject = ["toml"]
+requirements = ["pipreqs", "pip-api"]
+xdg_home = ["appdirs (>=1.4.0)"]
 
 [[package]]
 category = "dev"
@@ -184,8 +197,8 @@ category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
-python-versions = ">=3.4"
-version = "7.2.0"
+python-versions = ">=3.5"
+version = "8.0.2"
 
 [[package]]
 category = "dev"
@@ -200,13 +213,16 @@ mypy-extensions = ">=0.4.0,<0.5.0"
 typed-ast = ">=1.4.0,<1.5.0"
 typing-extensions = ">=3.7.4"
 
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+
 [[package]]
 category = "dev"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
 name = "mypy-extensions"
 optional = false
 python-versions = "*"
-version = "0.4.1"
+version = "0.4.3"
 
 [[package]]
 category = "dev"
@@ -222,16 +238,27 @@ six = "*"
 
 [[package]]
 category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.6.0"
+
+[[package]]
+category = "dev"
 description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.0"
+version = "0.13.1"
 
 [package.dependencies]
 [package.dependencies.importlib-metadata]
 python = "<3.8"
 version = ">=0.12"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
 
 [[package]]
 category = "dev"
@@ -273,13 +300,18 @@ optional = false
 python-versions = "*"
 version = "1.7.1"
 
+[package.extras]
+crypto = ["cryptography (>=1.4)"]
+flake8 = ["flake8", "flake8-import-order", "pep8-naming"]
+test = ["pytest (>=4.0.1,<5.0.0)", "pytest-cov (>=2.6.0,<3.0.0)", "pytest-runner (>=4.2,<5.0.0)"]
+
 [[package]]
 category = "dev"
 description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.2"
+version = "2.4.5"
 
 [[package]]
 category = "dev"
@@ -287,7 +319,7 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "5.1.2"
+version = "5.3.2"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -303,13 +335,16 @@ wcwidth = "*"
 python = "<3.8"
 version = ">=0.12"
 
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
 [[package]]
 category = "main"
 description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.8.0"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+version = "2.8.1"
 
 [package.dependencies]
 six = ">=1.5"
@@ -334,7 +369,15 @@ description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
 python-versions = "*"
-version = "2019.2"
+version = "2019.3"
+
+[[package]]
+category = "dev"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
+optional = false
+python-versions = "*"
+version = "2019.12.19"
 
 [[package]]
 category = "main"
@@ -350,13 +393,17 @@ chardet = ">=3.0.2,<3.1.0"
 idna = ">=2.5,<2.9"
 urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
 
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+
 [[package]]
 category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 category = "main"
@@ -364,7 +411,10 @@ description = "Pretty-print tabular data"
 name = "tabulate"
 optional = false
 python-versions = "*"
-version = "0.8.3"
+version = "0.8.6"
+
+[package.extras]
+widechars = ["wcwidth"]
 
 [[package]]
 category = "dev"
@@ -380,7 +430,10 @@ description = "Fast, Extensible Progress Meter"
 name = "tqdm"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "4.36.1"
+version = "4.40.2"
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown"]
 
 [[package]]
 category = "dev"
@@ -392,33 +445,11 @@ version = "1.4.0"
 
 [[package]]
 category = "dev"
-description = "Type Hints for Python"
-name = "typing"
-optional = false
-python-versions = "*"
-version = "3.7.4.1"
-
-[[package]]
-category = "dev"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
 optional = false
 python-versions = "*"
-version = "3.7.4"
-
-[package.dependencies]
-typing = ">=3.7.4"
-
-[[package]]
-category = "main"
-description = "tzinfo object for the local timezone"
-name = "tzlocal"
-optional = false
-python-versions = "*"
-version = "2.0.0"
-
-[package.dependencies]
-pytz = "*"
+version = "3.7.4.1"
 
 [[package]]
 category = "main"
@@ -426,7 +457,12 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
-version = "1.25.5"
+version = "1.25.7"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
 category = "dev"
@@ -448,58 +484,247 @@ version = "0.6.0"
 [package.dependencies]
 more-itertools = "*"
 
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pathlib2", "contextlib2", "unittest2"]
+
 [extras]
 server = ["python-jose-cryptodome"]
 
 [metadata]
-content-hash = "252a37c8bdbe25e5bf54294ec0b857b2e1e13e3662f3b87ed48f95398dd710c3"
+content-hash = "109a53d8b7a3a4b39cb0c4bcb4a2d8f2efdab06fd8227b29241a0361e1b99011"
 python-versions = "^3.6"
 
-[metadata.hashes]
-appdirs = ["9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92", "d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"]
-argcomplete = ["2f2052ea5156eb5cc7edce9c0ddc937e30c49c1097d51b24f34350a08632a264", "45836de8cc63d2f6e06b898cef1e4ce1e9907d246ec77ac8e64f23f153d6bec1"]
-atomicwrites = ["03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4", "75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"]
-attrs = ["69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"]
-auth0-python = ["bdeb7b0c5e74dd91aab67af9e4bf466a30df34d1eb5f7ea638db542108a29a51", "c2fdc3ff230638a2776d2b3761e787ca93dc33a26f841504fc260f947256f453"]
-black = ["09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf", "68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"]
-bump2version = ["524bde030318fe2543038defe0f77739605636fef96924883813cb290cf79c1e", "bfcc051498dda9fd9ac8634689f4516e1c20fdeeace3278932cc6e1248418b36"]
-certifi = ["e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50", "fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"]
-chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
-click = ["2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13", "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"]
-colorama = ["05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d", "f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"]
-dataclasses = ["454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f", "6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"]
-ecdsa = ["20c17e527e75acad8f402290e158a6ac178b91b881f941fc6ea305bfdfb9657c", "5c034ffa23413ac923541ceb3ac14ec15a0d2530690413bff58c12b80e56d884"]
-entrypoints = ["589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19", "c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"]
-flake8 = ["19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548", "8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"]
-future = ["67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"]
-idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
-importlib-metadata = ["aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26", "d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"]
-isort = ["54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1", "6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"]
-mccabe = ["ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42", "dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"]
-more-itertools = ["409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832", "92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"]
-mypy = ["0107bff4f46a289f0e4081d59b77cef1c48ea43da5a0dbf0005d54748b26df2a", "07957f5471b3bb768c61f08690c96d8a09be0912185a27a68700f3ede99184e4", "10af62f87b6921eac50271e667cc234162a194e742d8e02fc4ddc121e129a5b0", "11fd60d2f69f0cefbe53ce551acf5b1cec1a89e7ce2d47b4e95a84eefb2899ae", "15e43d3b1546813669bd1a6ec7e6a11d2888db938e0607f7b5eef6b976671339", "352c24ba054a89bb9a35dd064ee95ab9b12903b56c72a8d3863d882e2632dc76", "437020a39417e85e22ea8edcb709612903a9924209e10b3ec6d8c9f05b79f498", "49925f9da7cee47eebf3420d7c0e00ec662ec6abb2780eb0a16260a7ba25f9c4", "6724fcd5777aa6cebfa7e644c526888c9d639bd22edd26b2a8038c674a7c34bd", "7a17613f7ea374ab64f39f03257f22b5755335b73251d0d253687a69029701ba", "cdc1151ced496ca1496272da7fc356580e95f2682be1d32377c22ddebdf73c91"]
-mypy-extensions = ["37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812", "b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"]
-packaging = ["28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47", "d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"]
-pluggy = ["0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6", "fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"]
-py = ["64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa", "dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"]
-pycodestyle = ["95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56", "e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"]
-pycryptodome = ["1b52d5643e243a6d5ba4b5706e6ae59ee61b14e800ff812c1e47ec4dfe8e4761", "234c416c8ae31b4ffab57bf89e4b2812687f247263a90dbadc540ec511a2837d", "4e83913f03358e66ec675d5963886335919e0c3efaadb4b6e920f44199fd2ab9", "6277eee3979f19d03d7d02a4d256c4a52a5958709720a060faeb716ea83f2d48", "6e09c84b9e4e97bd9b1c763f43e48d248e8733f597c7c9f8cefca658d9c9f6b9", "76d03ca52cf61a0d21e161c251cd81f0c13494b6f6771cb934770fabceb58068", "ab96ff95cf879a57e2736f78238e2b731516f4b0e7c572b861d6b3eced42caf5", "ba62f6b9ae09a88cbe3328aa1ccc1696462d489c92f73920ec473773f2f92f84", "c292deeca9176c162e5a8e19be9c60edb99e855dbad3ea032f94e23249873ba6"]
-pyflakes = ["17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0", "d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"]
-pyjwt = ["5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e", "8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"]
-pyparsing = ["6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80", "d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"]
-pytest = ["95d13143cc14174ca1a01ec68e84d76ba5d9d493ac02716fd9706c949a505210", "b78fe2881323bd44fd9bd76e5317173d4316577e7b1cddebae9136a4495ec865"]
-python-dateutil = ["7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb", "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"]
-python-jose-cryptodome = ["4c42416ae9cf06cab312bc2f236099647162cc61f4376d3c8af60e465a5b5697", "9226693ee9ff52795ea8bfc70e0b77c62dca9a0f0fcbf9635c248d190211826e"]
-pytz = ["26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32", "c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"]
-requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
-six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
-tabulate = ["8af07a39377cee1103a5c8b3330a421c2d99b9141e9cc5ddd2e3263fea416943"]
-toml = ["229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c", "235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e", "f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"]
-tqdm = ["abc25d0ce2397d070ef07d8c7e706aede7920da163c64997585d42d3537ece3d", "dd3fcca8488bb1d416aa7469d2f277902f26260c45aa86b667b074cd44b3b115"]
-typed-ast = ["18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e", "262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e", "2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0", "354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c", "4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631", "630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4", "66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34", "71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b", "95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a", "bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233", "cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1", "d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36", "d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d", "d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a", "ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"]
-typing = ["91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23", "c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36", "f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"]
-typing-extensions = ["2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95", "b1edbbf0652660e32ae780ac9433f4231e7339c7f9a8057d0f042fcbcea49b87", "d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed"]
-tzlocal = ["11c9f16e0a633b4b60e1eede97d8a46340d042e67b670b290ca526576e039048", "949b9dd5ba4be17190a80c0268167d7e6c92c62b30026cf9764caf3e308e5590"]
-urllib3 = ["2f3eadfea5d92bc7899e75b5968410b749a054b492d5a6379c1344a1481bc2cb", "9c6c593cb28f52075016307fc26b0a0f8e82bc7d1ff19aaaa959b91710a56c47"]
-wcwidth = ["3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e", "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"]
-zipp = ["3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e", "f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"]
+[metadata.files]
+appdirs = [
+    {file = "appdirs-1.4.3-py2.py3-none-any.whl", hash = "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"},
+    {file = "appdirs-1.4.3.tar.gz", hash = "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.3.0-py2.py3-none-any.whl", hash = "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"},
+    {file = "atomicwrites-1.3.0.tar.gz", hash = "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"},
+]
+attrs = [
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+]
+auth0-python = [
+    {file = "auth0-python-3.9.1.tar.gz", hash = "sha256:c2fdc3ff230638a2776d2b3761e787ca93dc33a26f841504fc260f947256f453"},
+    {file = "auth0_python-3.9.1-py2.py3-none-any.whl", hash = "sha256:bdeb7b0c5e74dd91aab67af9e4bf466a30df34d1eb5f7ea638db542108a29a51"},
+]
+black = [
+    {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
+    {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
+]
+certifi = [
+    {file = "certifi-2019.11.28-py2.py3-none-any.whl", hash = "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"},
+    {file = "certifi-2019.11.28.tar.gz", hash = "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"},
+]
+chardet = [
+    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
+    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
+click = [
+    {file = "Click-7.0-py2.py3-none-any.whl", hash = "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13"},
+    {file = "Click-7.0.tar.gz", hash = "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"},
+]
+colorama = [
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+dataclasses = [
+    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
+    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
+]
+ecdsa = [
+    {file = "ecdsa-0.14.1-py2.py3-none-any.whl", hash = "sha256:e108a5fe92c67639abae3260e43561af914e7fd0d27bae6d2ec1312ae7934dfe"},
+    {file = "ecdsa-0.14.1.tar.gz", hash = "sha256:64c613005f13efec6541bb0a33290d0d03c27abab5f15fbab20fb0ee162bdd8e"},
+]
+entrypoints = [
+    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
+    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
+]
+flake8 = [
+    {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
+    {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+]
+future = [
+    {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
+idna = [
+    {file = "idna-2.8-py2.py3-none-any.whl", hash = "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"},
+    {file = "idna-2.8.tar.gz", hash = "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-1.3.0-py2.py3-none-any.whl", hash = "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"},
+    {file = "importlib_metadata-1.3.0.tar.gz", hash = "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45"},
+]
+isort = [
+    {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
+    {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+more-itertools = [
+    {file = "more-itertools-8.0.2.tar.gz", hash = "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d"},
+    {file = "more_itertools-8.0.2-py3-none-any.whl", hash = "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"},
+]
+mypy = [
+    {file = "mypy-0.720-cp35-cp35m-macosx_10_6_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:437020a39417e85e22ea8edcb709612903a9924209e10b3ec6d8c9f05b79f498"},
+    {file = "mypy-0.720-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:10af62f87b6921eac50271e667cc234162a194e742d8e02fc4ddc121e129a5b0"},
+    {file = "mypy-0.720-cp35-cp35m-win_amd64.whl", hash = "sha256:0107bff4f46a289f0e4081d59b77cef1c48ea43da5a0dbf0005d54748b26df2a"},
+    {file = "mypy-0.720-cp36-cp36m-macosx_10_6_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:352c24ba054a89bb9a35dd064ee95ab9b12903b56c72a8d3863d882e2632dc76"},
+    {file = "mypy-0.720-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:7a17613f7ea374ab64f39f03257f22b5755335b73251d0d253687a69029701ba"},
+    {file = "mypy-0.720-cp36-cp36m-win_amd64.whl", hash = "sha256:07957f5471b3bb768c61f08690c96d8a09be0912185a27a68700f3ede99184e4"},
+    {file = "mypy-0.720-cp37-cp37m-macosx_10_6_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:6724fcd5777aa6cebfa7e644c526888c9d639bd22edd26b2a8038c674a7c34bd"},
+    {file = "mypy-0.720-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:15e43d3b1546813669bd1a6ec7e6a11d2888db938e0607f7b5eef6b976671339"},
+    {file = "mypy-0.720-cp37-cp37m-win_amd64.whl", hash = "sha256:cdc1151ced496ca1496272da7fc356580e95f2682be1d32377c22ddebdf73c91"},
+    {file = "mypy-0.720-py3-none-any.whl", hash = "sha256:11fd60d2f69f0cefbe53ce551acf5b1cec1a89e7ce2d47b4e95a84eefb2899ae"},
+    {file = "mypy-0.720.tar.gz", hash = "sha256:49925f9da7cee47eebf3420d7c0e00ec662ec6abb2780eb0a16260a7ba25f9c4"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+packaging = [
+    {file = "packaging-19.2-py2.py3-none-any.whl", hash = "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"},
+    {file = "packaging-19.2.tar.gz", hash = "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47"},
+]
+pathspec = [
+    {file = "pathspec-0.6.0.tar.gz", hash = "sha256:e285ccc8b0785beadd4c18e5708b12bb8fcf529a1e61215b3feff1d1e559ea5c"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+py = [
+    {file = "py-1.8.0-py2.py3-none-any.whl", hash = "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa"},
+    {file = "py-1.8.0.tar.gz", hash = "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
+    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
+]
+pycryptodome = [
+    {file = "pycryptodome-3.3.1-cp27-none-win32.whl", hash = "sha256:c292deeca9176c162e5a8e19be9c60edb99e855dbad3ea032f94e23249873ba6"},
+    {file = "pycryptodome-3.3.1-cp27-none-win_amd64.whl", hash = "sha256:ba62f6b9ae09a88cbe3328aa1ccc1696462d489c92f73920ec473773f2f92f84"},
+    {file = "pycryptodome-3.3.1-cp33-none-win32.whl", hash = "sha256:6277eee3979f19d03d7d02a4d256c4a52a5958709720a060faeb716ea83f2d48"},
+    {file = "pycryptodome-3.3.1-cp33-none-win_amd64.whl", hash = "sha256:234c416c8ae31b4ffab57bf89e4b2812687f247263a90dbadc540ec511a2837d"},
+    {file = "pycryptodome-3.3.1-cp34-none-win32.whl", hash = "sha256:ab96ff95cf879a57e2736f78238e2b731516f4b0e7c572b861d6b3eced42caf5"},
+    {file = "pycryptodome-3.3.1-cp34-none-win_amd64.whl", hash = "sha256:76d03ca52cf61a0d21e161c251cd81f0c13494b6f6771cb934770fabceb58068"},
+    {file = "pycryptodome-3.3.1-cp35-none-win32.whl", hash = "sha256:6e09c84b9e4e97bd9b1c763f43e48d248e8733f597c7c9f8cefca658d9c9f6b9"},
+    {file = "pycryptodome-3.3.1-cp35-none-win_amd64.whl", hash = "sha256:4e83913f03358e66ec675d5963886335919e0c3efaadb4b6e920f44199fd2ab9"},
+    {file = "pycryptodome-3.3.1.tar.gz", hash = "sha256:1b52d5643e243a6d5ba4b5706e6ae59ee61b14e800ff812c1e47ec4dfe8e4761"},
+]
+pyflakes = [
+    {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
+    {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
+]
+pyjwt = [
+    {file = "PyJWT-1.7.1-py2.py3-none-any.whl", hash = "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e"},
+    {file = "PyJWT-1.7.1.tar.gz", hash = "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.5-py2.py3-none-any.whl", hash = "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f"},
+    {file = "pyparsing-2.4.5.tar.gz", hash = "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"},
+]
+pytest = [
+    {file = "pytest-5.3.2-py3-none-any.whl", hash = "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"},
+    {file = "pytest-5.3.2.tar.gz", hash = "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+python-jose-cryptodome = [
+    {file = "python-jose-cryptodome-1.3.2.tar.gz", hash = "sha256:9226693ee9ff52795ea8bfc70e0b77c62dca9a0f0fcbf9635c248d190211826e"},
+    {file = "python_jose_cryptodome-1.3.2-py2.py3-none-any.whl", hash = "sha256:4c42416ae9cf06cab312bc2f236099647162cc61f4376d3c8af60e465a5b5697"},
+]
+pytz = [
+    {file = "pytz-2019.3-py2.py3-none-any.whl", hash = "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d"},
+    {file = "pytz-2019.3.tar.gz", hash = "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"},
+]
+regex = [
+    {file = "regex-2019.12.19-cp27-cp27m-win32.whl", hash = "sha256:ba449b56fa419fb19bf2a2438adbd2433f27087a6fe115917eaf9cfca684d5b6"},
+    {file = "regex-2019.12.19-cp27-cp27m-win_amd64.whl", hash = "sha256:4eeb0fe936797ae00a085f99802642bfc722b3b4ea557e9e7849cb621ea10c91"},
+    {file = "regex-2019.12.19-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:47298bc8b89d1c747f0f5974aa528fc0b6b17396f1694136a224d51461279d83"},
+    {file = "regex-2019.12.19-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:7c5e2efcf079c35ff266c3f3a6708834f88f9fd04a3c16b855e036b2b7b1b543"},
+    {file = "regex-2019.12.19-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:16709434c4e2332ee8ba26ae339aceb8ab0b24b8398ebd0f52ebc943f45c4fc2"},
+    {file = "regex-2019.12.19-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:d51311496061863caae2cfe120cf1ef37900019b86c89c2d75f0918e0b4b8bf3"},
+    {file = "regex-2019.12.19-cp36-cp36m-win32.whl", hash = "sha256:2404a50fb48badaf214b700f08822b68d93d79200e0aefd9569d0332d21fbfcb"},
+    {file = "regex-2019.12.19-cp36-cp36m-win_amd64.whl", hash = "sha256:999a885f7f5194464238ad5d74b05982acee54002f3aa775d8e0e8c5fb74c06c"},
+    {file = "regex-2019.12.19-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:223fb63ec8dcab20b3318e93dcec4aee89e98b062934090bf29ffc374d2000a2"},
+    {file = "regex-2019.12.19-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d3f632cefad2cf247bd845794002585e3772288bfcb0dbac59fdecd32cd38b67"},
+    {file = "regex-2019.12.19-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:a2e1e53df7dd27943da2b512895125b33fb20f81862c9fed7b3bab2a1de684d1"},
+    {file = "regex-2019.12.19-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ab43bc0836820b7900dfffc025b996784aec26ec87dc1df4f95a40398760223f"},
+    {file = "regex-2019.12.19-cp37-cp37m-win32.whl", hash = "sha256:23c3ebf05d1cd3adb26723fd598e75724e0cdb7d6a35185ac0caf061cc6edb49"},
+    {file = "regex-2019.12.19-cp37-cp37m-win_amd64.whl", hash = "sha256:37e018d3746baf159aedfc9773c3cafacbd10d354ba15484f5cfc8ed9da5748b"},
+    {file = "regex-2019.12.19-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0472acc4b6319801c1bc681d838c88ba1446f9ae199e01f6e41091c701fb3d42"},
+    {file = "regex-2019.12.19-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2af3a7a16fed6eff85c25da106effa36f61cbbe801d00ade349b53ce7619eb15"},
+    {file = "regex-2019.12.19-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:3c9c2988d02a9238a1975c70e87c6ce94e6f36dd8e372b66f468990cfe077434"},
+    {file = "regex-2019.12.19-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:9fd2f4813eaa3e421e82819d38e5b634d900faff7ae5a80cd89ccff407175e69"},
+    {file = "regex-2019.12.19-cp38-cp38-win32.whl", hash = "sha256:7ac08cee5055f548eed3889e9aaef15fd00172d037949496f1f0b34acb8a7c3e"},
+    {file = "regex-2019.12.19-cp38-cp38-win_amd64.whl", hash = "sha256:6881be0218b47ed76db033f252bab3f912dfe7ed1fe7baa9daebf51de08546a0"},
+    {file = "regex-2019.12.19.tar.gz", hash = "sha256:8355eaa64724a0fdb010a1654b77cb3e375dc08b7f592cc4a1c05ac606aa481c"},
+]
+requests = [
+    {file = "requests-2.22.0-py2.py3-none-any.whl", hash = "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"},
+    {file = "requests-2.22.0.tar.gz", hash = "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"},
+]
+six = [
+    {file = "six-1.13.0-py2.py3-none-any.whl", hash = "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd"},
+    {file = "six-1.13.0.tar.gz", hash = "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"},
+]
+tabulate = [
+    {file = "tabulate-0.8.6.tar.gz", hash = "sha256:5470cc6687a091c7042cee89b2946d9235fe9f6d49c193a4ae2ac7bf386737c8"},
+]
+toml = [
+    {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
+    {file = "toml-0.10.0-py2.py3-none-any.whl", hash = "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"},
+    {file = "toml-0.10.0.tar.gz", hash = "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"},
+]
+tqdm = [
+    {file = "tqdm-4.40.2-py2.py3-none-any.whl", hash = "sha256:7543892c59720e36e4212180274d8f58dde36803bc1f6370fd09afa20b8f5892"},
+    {file = "tqdm-4.40.2.tar.gz", hash = "sha256:f0ab01cf3ae5673d18f918700c0165e5fad0f26b5ebe4b34f62ead92686b5340"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e"},
+    {file = "typed_ast-1.4.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b"},
+    {file = "typed_ast-1.4.0-cp35-cp35m-win32.whl", hash = "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4"},
+    {file = "typed_ast-1.4.0-cp35-cp35m-win_amd64.whl", hash = "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-win32.whl", hash = "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-win32.whl", hash = "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0"},
+    {file = "typed_ast-1.4.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66"},
+    {file = "typed_ast-1.4.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2"},
+    {file = "typed_ast-1.4.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47"},
+    {file = "typed_ast-1.4.0-cp38-cp38-win32.whl", hash = "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161"},
+    {file = "typed_ast-1.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e"},
+    {file = "typed_ast-1.4.0.tar.gz", hash = "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.1-py2-none-any.whl", hash = "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d"},
+    {file = "typing_extensions-3.7.4.1-py3-none-any.whl", hash = "sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575"},
+    {file = "typing_extensions-3.7.4.1.tar.gz", hash = "sha256:091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2"},
+]
+urllib3 = [
+    {file = "urllib3-1.25.7-py2.py3-none-any.whl", hash = "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293"},
+    {file = "urllib3-1.25.7.tar.gz", hash = "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"},
+]
+wcwidth = [
+    {file = "wcwidth-0.1.7-py2.py3-none-any.whl", hash = "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"},
+    {file = "wcwidth-0.1.7.tar.gz", hash = "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e"},
+]
+zipp = [
+    {file = "zipp-0.6.0-py2.py3-none-any.whl", hash = "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"},
+    {file = "zipp-0.6.0.tar.gz", hash = "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.0.0"]
 build-backend = "poetry.masonry.api"
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry>=1.0.0"]
+requires = ["poetry>=1.0"]
 build-backend = "poetry.masonry.api"
 
 [tool.poetry]


### PR DESCRIPTION
## Why?
* Reduce code duplication (from 3 dupes to 2) when defining a model
  * A future PR will tackle the last duplication, which requires changing [de]serialization implementation
* Take advantage of nice `dataclass` features

## What changed?
- [x] Updated models to use `@dataclass`
- [x] Bumped `poetry` to 1.0 and updated lock file