### PR TITLE
Serializable CTR object for injecting CTR records into ETL channels

### DIFF
--- a/contxt/models/changetrackingrecord.py
+++ b/contxt/models/changetrackingrecord.py
@@ -24,7 +24,7 @@ class ChangeTrackingRecord:
        ingestable by the ndustrial ETL java/kotlin components.
        
        topic: Str           - the name of the canonical being ETL-ed
-       version: Str         - some long identification I'm not sure
+       version: Str         - the change table version or CDC version number (cursor position)
        operation: enum      - a DB operation (insert/update/upsert/delete) from the DBOperation enum
        source_host: Str     - the hostname/ip/table that homes the source data
        source_table: Str    - the name of the table from where the data is being extracted

--- a/contxt/models/changetrackingrecord.py
+++ b/contxt/models/changetrackingrecord.py
@@ -1,24 +1,26 @@
+import json
 from enum import Enum
 
-import json
 
 class DBOperation(Enum):
     INSERT = 0
-    UPDATE = 1 
-    UPSERT = 2 
+    UPDATE = 1
+    UPSERT = 2
     DELETE = 3
 
     @classmethod
     def has_value(cls, value):
-        return value in cls._value2member_map_ 
+        return value in cls._value2member_map_
 
-class CTRHeader():
-    def __init__(self, forwardable = True, deduplicatable = True):
+
+class CTRHeader:
+    def __init__(self, forwardable=True, deduplicatable=True):
         self.forwardable = forwardable
         self.deduplicatable = deduplicatable
 
-class ChangeTrackingRecord():
-    '''A JSON Serializable ndustrial.io ChangeTrackingRecord(tm) that is
+
+class ChangeTrackingRecord:
+    """A JSON Serializable ndustrial.io ChangeTrackingRecord(tm) that is
        ingestable by the ndustrial ETL java/kotlin components.
        
        topic: Str           - the name of the canonical being ETL-ed
@@ -30,7 +32,8 @@ class ChangeTrackingRecord():
        tuple: dict          - key/value pairs that make up the data payload. This
                               value defaults to an empty dict and can be updated after creation
        headers: CTRHeader() - the header information that informs ETL devices what do with the CTR
-    '''
+    """
+
     def __init__(
         self,
         topic: str,
@@ -39,15 +42,16 @@ class ChangeTrackingRecord():
         source_host: str,
         source_table: str,
         source_database: str,
-        tuple = dict(),
-        headers = CTRHeader()):
+        tuple=dict(),
+        headers=CTRHeader(),
+    ):
 
         errors = ""
         if type(topic) is not str:
             errors += "\nTopic parameter must be a string"
         if type(version) is not int:
             errors += "\nVersion parameter must be long (int)"
-        if not(DBOperation.has_value(operation)):
+        if not (DBOperation.has_value(operation)):
             errors += "\nOperation parameter must be member of DBOperation enum"
         if type(source_host) is not str:
             errors += "\nsource_host parameter must be a string"
@@ -56,9 +60,8 @@ class ChangeTrackingRecord():
         if type(source_database) is not str:
             errors += "\nsource_database parameter must be a string"
 
-        if (errors):
+        if errors:
             raise AttributeError(errors)
-
 
         self.topic = topic
         self.version = version
@@ -69,7 +72,6 @@ class ChangeTrackingRecord():
         self.tuple = tuple
         self.headers = headers
         self.addlParams = dict()
-
 
     def getJSONString(self) -> str:
         return json.dumps(self, default=lambda x: x.__dict__)

--- a/contxt/models/changetrackingrecord.py
+++ b/contxt/models/changetrackingrecord.py
@@ -1,6 +1,6 @@
 from enum import Enum
-import json
 
+import json
 
 class DBOperation(Enum):
     INSERT = 0

--- a/contxt/models/changetrackingrecord.py
+++ b/contxt/models/changetrackingrecord.py
@@ -22,7 +22,7 @@ class CTRHeader:
 class ChangeTrackingRecord:
     """A JSON Serializable ndustrial.io ChangeTrackingRecord(tm) that is
        ingestable by the ndustrial ETL java/kotlin components.
-       
+
        topic: Str           - the name of the canonical being ETL-ed
        version: Str         - the change table version or CDC version number (cursor position)
        operation: enum      - a DB operation (insert/update/upsert/delete) from the DBOperation enum

--- a/contxt/models/changetrackingrecord.py
+++ b/contxt/models/changetrackingrecord.py
@@ -1,0 +1,75 @@
+from enum import Enum
+import json
+
+
+class DBOperation(Enum):
+    INSERT = 0
+    UPDATE = 1 
+    UPSERT = 2 
+    DELETE = 3
+
+    @classmethod
+    def has_value(cls, value):
+        return value in cls._value2member_map_ 
+
+class CTRHeader():
+    def __init__(self, forwardable = True, deduplicatable = True):
+        self.forwardable = forwardable
+        self.deduplicatable = deduplicatable
+
+class ChangeTrackingRecord():
+    '''A JSON Serializable ndustrial.io ChangeTrackingRecord(tm) that is
+       ingestable by the ndustrial ETL java/kotlin components.
+       
+       topic: Str           - the name of the canonical being ETL-ed
+       version: Str         - some long identification I'm not sure
+       operation: enum      - a DB operation (insert/update/upsert/delete) from the DBOperation enum
+       source_host: Str     - the hostname/ip/table that homes the source data
+       source_table: Str    - the name of the table from where the data is being extracted
+       source_database: Str - the name of the db being extracted against
+       tuple: dict          - key/value pairs that make up the data payload. This
+                              value defaults to an empty dict and can be updated after creation
+       headers: CTRHeader() - the header information that informs ETL devices what do with the CTR
+    '''
+    def __init__(
+        self,
+        topic: str,
+        version: int,
+        operation: DBOperation,
+        source_host: str,
+        source_table: str,
+        source_database: str,
+        tuple = dict(),
+        headers = CTRHeader()):
+
+        errors = ""
+        if type(topic) is not str:
+            errors += "\nTopic parameter must be a string"
+        if type(version) is not int:
+            errors += "\nVersion parameter must be long (int)"
+        if not(DBOperation.has_value(operation)):
+            errors += "\nOperation parameter must be member of DBOperation enum"
+        if type(source_host) is not str:
+            errors += "\nsource_host parameter must be a string"
+        if type(source_table) is not str:
+            errors += "\nsource_host parameter must be a string"
+        if type(source_database) is not str:
+            errors += "\nsource_database parameter must be a string"
+
+        if (errors):
+            raise AttributeError(errors)
+
+
+        self.topic = topic
+        self.version = version
+        self.operation = operation
+        self.source_host = source_host
+        self.source_table = source_table
+        self.source_database = source_database
+        self.tuple = tuple
+        self.headers = headers
+        self.addlParams = dict()
+
+
+    def getJSONString(self) -> str:
+        return json.dumps(self, default=lambda x: x.__dict__)

--- a/tests/unit/test_ctr.py
+++ b/tests/unit/test_ctr.py
@@ -43,8 +43,8 @@ def test_ctr_wrong_db():
 def test_get_json_string():
     ctr = ChangeTrackingRecord("myTopic", 1020304, 0, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3})
     expected = ('{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", '
-    '"source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, '
-    '"headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {}}')
+        '"source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, '
+        '"headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {}}')
     assert ctr.getJSONString() == expected
 
 
@@ -60,8 +60,8 @@ def test_set_headers():
         CTRHeader(forwardable=False, deduplicatable=False),
     )
     expected = ('{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", '
-    '"source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, '
-    '"headers": {"forwardable": false, "deduplicatable": false}, "addlParams": {}}')
+        '"source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, '
+        '"headers": {"forwardable": false, "deduplicatable": false}, "addlParams": {}}')
     assert ctr.getJSONString() == expected
 
 
@@ -69,6 +69,6 @@ def test_get_json_addl_params():
     ctr = ChangeTrackingRecord("myTopic", 1020304, 0, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3})
     ctr.addlParams = {"forwardChannel": "canonical-fwd"}
     expected = ('{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce",'
-    ' "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, '
-    '"headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {"forwardChannel": "canonical-fwd"}}')
+        ' "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, '
+        '"headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {"forwardChannel": "canonical-fwd"}}')
     assert ctr.getJSONString() == expected

--- a/tests/unit/test_ctr.py
+++ b/tests/unit/test_ctr.py
@@ -1,0 +1,46 @@
+import pytest
+from contxt.models.changetrackingrecord import ChangeTrackingRecord, CTRHeader
+
+def test_ctr_wrong_topic():
+    with pytest.raises(AttributeError):
+        ChangeTrackingRecord(404,1020304,0,"soruce","table","db", {'a':1,'b':2,'c':3})
+
+def test_ctr_wrong_version_str():
+    with pytest.raises(AttributeError):
+        ChangeTrackingRecord("Mytopic","1.1.0",0,"soruce","table","db", {'a':1,'b':2,'c':3})
+
+def test_ctr_wrong_version_float():
+    with pytest.raises(AttributeError):
+        ChangeTrackingRecord("Mytopic",534543.9457,0,"soruce","table","db", {'a':1,'b':2,'c':3})
+
+def test_ctr_wrong_operation():
+    with pytest.raises(AttributeError):
+        ChangeTrackingRecord("Mytopic",120304,9,"soruce","table","db", {'a':1,'b':2,'c':3})
+
+def test_ctr_wrong_host():
+    with pytest.raises(AttributeError):
+        ChangeTrackingRecord("Mytopic",1020304,0,3480,"table","db", {'a':1,'b':2,'c':3})
+
+def test_ctr_wrong_table():
+    with pytest.raises(AttributeError):
+        ChangeTrackingRecord(404,1020304,0,"soruce",766,"db", {'a':1,'b':2,'c':3})
+
+def test_ctr_wrong_db():
+    with pytest.raises(AttributeError):
+        ChangeTrackingRecord(404,1020304,0,"soruce","table",404, {'a':1,'b':2,'c':3})
+
+def test_get_json_string():
+    ctr = ChangeTrackingRecord("myTopic",1020304,0,"soruce","table","db", {'a':1,'b':2,'c':3})
+    expected = '{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, "headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {}}'
+    assert(ctr.getJSONString() == expected)
+
+def test_set_headers():
+    ctr = ChangeTrackingRecord("myTopic",1020304,0,"soruce","table","db", {'a':1,'b':2,'c':3}, CTRHeader(forwardable=False, deduplicatable=False))
+    expected = '{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, "headers": {"forwardable": false, "deduplicatable": false}, "addlParams": {}}'
+    assert(ctr.getJSONString() == expected)
+
+def test_get_json_string():
+    ctr = ChangeTrackingRecord("myTopic",1020304,0,"soruce","table","db", {'a':1,'b':2,'c':3})
+    ctr.addlParams = {'forwardChannel':'canonical-fwd'}
+    expected = '{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, "headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {"forwardChannel": "canonical-fwd"}}'
+    assert(ctr.getJSONString() == expected)

--- a/tests/unit/test_ctr.py
+++ b/tests/unit/test_ctr.py
@@ -2,46 +2,67 @@ import pytest
 
 from contxt.models.changetrackingrecord import ChangeTrackingRecord, CTRHeader
 
+
 def test_ctr_wrong_topic():
     with pytest.raises(AttributeError):
-        ChangeTrackingRecord(404,1020304,0,"soruce","table","db", {'a':1,'b':2,'c':3})
+        ChangeTrackingRecord(404, 1020304, 0, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3})
+
 
 def test_ctr_wrong_version_str():
     with pytest.raises(AttributeError):
-        ChangeTrackingRecord("Mytopic","1.1.0",0,"soruce","table","db", {'a':1,'b':2,'c':3})
+        ChangeTrackingRecord("Mytopic", "1.1.0", 0, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3})
+
 
 def test_ctr_wrong_version_float():
     with pytest.raises(AttributeError):
-        ChangeTrackingRecord("Mytopic",534543.9457,0,"soruce","table","db", {'a':1,'b':2,'c':3})
+        ChangeTrackingRecord(
+            "Mytopic", 534543.9457, 0, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3}
+        )
+
 
 def test_ctr_wrong_operation():
     with pytest.raises(AttributeError):
-        ChangeTrackingRecord("Mytopic",120304,9,"soruce","table","db", {'a':1,'b':2,'c':3})
+        ChangeTrackingRecord("Mytopic", 120304, 9, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3})
+
 
 def test_ctr_wrong_host():
     with pytest.raises(AttributeError):
-        ChangeTrackingRecord("Mytopic",1020304,0,3480,"table","db", {'a':1,'b':2,'c':3})
+        ChangeTrackingRecord("Mytopic", 1020304, 0, 3480, "table", "db", {"a": 1, "b": 2, "c": 3})
+
 
 def test_ctr_wrong_table():
     with pytest.raises(AttributeError):
-        ChangeTrackingRecord(404,1020304,0,"soruce",766,"db", {'a':1,'b':2,'c':3})
+        ChangeTrackingRecord(404, 1020304, 0, "soruce", 766, "db", {"a": 1, "b": 2, "c": 3})
+
 
 def test_ctr_wrong_db():
     with pytest.raises(AttributeError):
-        ChangeTrackingRecord(404,1020304,0,"soruce","table",404, {'a':1,'b':2,'c':3})
+        ChangeTrackingRecord(404, 1020304, 0, "soruce", "table", 404, {"a": 1, "b": 2, "c": 3})
+
 
 def test_get_json_string():
-    ctr = ChangeTrackingRecord("myTopic",1020304,0,"soruce","table","db", {'a':1,'b':2,'c':3})
+    ctr = ChangeTrackingRecord("myTopic", 1020304, 0, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3})
     expected = '{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, "headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {}}'
-    assert(ctr.getJSONString() == expected)
+    assert ctr.getJSONString() == expected
+
 
 def test_set_headers():
-    ctr = ChangeTrackingRecord("myTopic",1020304,0,"soruce","table","db", {'a':1,'b':2,'c':3}, CTRHeader(forwardable=False, deduplicatable=False))
+    ctr = ChangeTrackingRecord(
+        "myTopic",
+        1020304,
+        0,
+        "soruce",
+        "table",
+        "db",
+        {"a": 1, "b": 2, "c": 3},
+        CTRHeader(forwardable=False, deduplicatable=False),
+    )
     expected = '{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, "headers": {"forwardable": false, "deduplicatable": false}, "addlParams": {}}'
-    assert(ctr.getJSONString() == expected)
+    assert ctr.getJSONString() == expected
+
 
 def test_get_json_string():
-    ctr = ChangeTrackingRecord("myTopic",1020304,0,"soruce","table","db", {'a':1,'b':2,'c':3})
-    ctr.addlParams = {'forwardChannel':'canonical-fwd'}
+    ctr = ChangeTrackingRecord("myTopic", 1020304, 0, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3})
+    ctr.addlParams = {"forwardChannel": "canonical-fwd"}
     expected = '{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, "headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {"forwardChannel": "canonical-fwd"}}'
-    assert(ctr.getJSONString() == expected)
+    assert ctr.getJSONString() == expected

--- a/tests/unit/test_ctr.py
+++ b/tests/unit/test_ctr.py
@@ -42,7 +42,9 @@ def test_ctr_wrong_db():
 
 def test_get_json_string():
     ctr = ChangeTrackingRecord("myTopic", 1020304, 0, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3})
-    expected = '{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, "headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {}}'
+    expected = ('{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", '
+    '"source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, '
+    '"headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {}}')
     assert ctr.getJSONString() == expected
 
 
@@ -57,12 +59,16 @@ def test_set_headers():
         {"a": 1, "b": 2, "c": 3},
         CTRHeader(forwardable=False, deduplicatable=False),
     )
-    expected = '{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, "headers": {"forwardable": false, "deduplicatable": false}, "addlParams": {}}'
+    expected = ('{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", '
+    '"source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, '
+    '"headers": {"forwardable": false, "deduplicatable": false}, "addlParams": {}}')
     assert ctr.getJSONString() == expected
 
 
-def test_get_json_string():
+def test_get_json_addl_params():
     ctr = ChangeTrackingRecord("myTopic", 1020304, 0, "soruce", "table", "db", {"a": 1, "b": 2, "c": 3})
     ctr.addlParams = {"forwardChannel": "canonical-fwd"}
-    expected = '{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce", "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, "headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {"forwardChannel": "canonical-fwd"}}'
+    expected = ('{"topic": "myTopic", "version": 1020304, "operation": 0, "source_host": "soruce",'
+    ' "source_table": "table", "source_database": "db", "tuple": {"a": 1, "b": 2, "c": 3}, '
+    '"headers": {"forwardable": true, "deduplicatable": true}, "addlParams": {"forwardChannel": "canonical-fwd"}}')
     assert ctr.getJSONString() == expected

--- a/tests/unit/test_ctr.py
+++ b/tests/unit/test_ctr.py
@@ -1,4 +1,5 @@
 import pytest
+
 from contxt.models.changetrackingrecord import ChangeTrackingRecord, CTRHeader
 
 def test_ctr_wrong_topic():


### PR DESCRIPTION
## Why?
* [JIRA](NA): ETL CLI upgrades for injecting CTRs into messaging channels begs the need for a serializable CTR object that can be instantiated and manipulated and dumped into json and put on a message que

## What changed?
- [x] Created CTR object for future integrations
- [x] Tests
