### PR TITLE
Updating the version to latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Create GitHub release
-        uses: marvinpinto/action-automatic-releases@v1.0.0
+        # https://github.com/marvinpinto/actions/issues/39 We have to use latest due to a breaking change
+        uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false


### PR DESCRIPTION
## Why?
https://github.com/marvinpinto/actions/issues/39 A spelling change broke the action because it was somehow changed without updating the version number. The repo owner suggests changing it to latest until he gets around to versioning it.
