### PR TITLE
Defaulting ID to none for triggered events

### DIFF
--- a/contxt/models/events.py
+++ b/contxt/models/events.py
@@ -148,7 +148,7 @@ class TriggeredEvent(ApiObject):
 
     event_id: str
     trigger_start_at: datetime
-    id: Optional[str]
+    id: Optional[str] = None
     owner_id: Optional[str] = None
     owner: Optional[Owner] = None
     event: Optional[Event] = None


### PR DESCRIPTION
## Why?
The default should be None for creating
