### PR TITLE
Support for projects + EMS exports

### DIFF
--- a/contxt/cli/commands/__init__.py
+++ b/contxt/cli/commands/__init__.py
@@ -8,3 +8,4 @@ from .contxt import Contxt
 from .ems import Ems
 from .iot import Iot
 from .projects import Projects
+from .service import Services

--- a/contxt/cli/commands/__init__.py
+++ b/contxt/cli/commands/__init__.py
@@ -7,3 +7,4 @@ from .bus import Bus
 from .contxt import Contxt
 from .ems import Ems
 from .iot import Iot
+from .projects import Projects

--- a/contxt/cli/commands/assets.py
+++ b/contxt/cli/commands/assets.py
@@ -51,7 +51,9 @@ class Assets(BaseParser):
         facilites_service = FacilitiesService(args.auth)
         organization_id = args.org_id or get_org_id(args.org_name, args.auth)
         facilities = facilites_service.get_facilities(organization_id)
-        print(Serializer.to_table(facilities, exclude_keys=['info', 'organization', 'tags'], sort_by='id'))
+        print(
+            Serializer.to_table(facilities, exclude_keys=["info", "organization", "tags"], sort_by="id")
+        )
 
     def _types(self, args):
         organization_id = args.org_id or get_org_id(args.org_name, args.auth)

--- a/contxt/cli/commands/assets.py
+++ b/contxt/cli/commands/assets.py
@@ -59,12 +59,12 @@ class Assets(BaseParser):
         if not args.type_label:
             # Get all asset types
             asset_types = assets_service.types_by_id.values()
-            print(asset_types)
+            print(Serializer.to_table(asset_types))
         else:
             # Get single asset type
             asset_type = assets_service.asset_type_with_label(args.type_label)
             assets_service._cache_asset_type_full(asset_type)
-            print(asset_type)
+            print(Serializer.to_table(asset_type))
 
     def _assets(self, args):
         organization_id = args.org_id or get_org_id(args.org_name, args.auth)

--- a/contxt/cli/commands/assets.py
+++ b/contxt/cli/commands/assets.py
@@ -51,7 +51,7 @@ class Assets(BaseParser):
         facilites_service = FacilitiesService(args.auth)
         organization_id = args.org_id or get_org_id(args.org_name, args.auth)
         facilities = facilites_service.get_facilities(organization_id)
-        print(Serializer.to_table(facilities))
+        print(Serializer.to_table(facilities, exclude_keys=['info', 'organization', 'tags'], sort_by='id'))
 
     def _types(self, args):
         organization_id = args.org_id or get_org_id(args.org_name, args.auth)

--- a/contxt/cli/commands/assets.py
+++ b/contxt/cli/commands/assets.py
@@ -1,4 +1,5 @@
 from contxt.services import AssetsService, FacilitiesService
+from contxt.utils.serializer import Serializer
 
 from .common import BaseParser, get_org_id
 
@@ -50,7 +51,7 @@ class Assets(BaseParser):
         facilites_service = FacilitiesService(args.auth)
         organization_id = args.org_id or get_org_id(args.org_name, args.auth)
         facilities = facilites_service.get_facilities(organization_id)
-        print(facilities)
+        print(Serializer.to_table(facilities))
 
     def _types(self, args):
         organization_id = args.org_id or get_org_id(args.org_name, args.auth)

--- a/contxt/cli/commands/contxt.py
+++ b/contxt/cli/commands/contxt.py
@@ -50,7 +50,7 @@ class Contxt(BaseParser):
         contxt_service = ContxtService(args.auth)
         organization_id = args.org_id or get_org_id(args.org_name, args.auth)
         users = contxt_service.get_users_for_organization(organization_id)
-        print(users)
+        print(Serializer.to_table(users))
 
     def _add_user(self, args):
         contxt_service = ContxtService(args.auth)

--- a/contxt/cli/commands/ems.py
+++ b/contxt/cli/commands/ems.py
@@ -207,10 +207,9 @@ class Ems(BaseParser):
                 try_count = 0
                 while try_count < 3:
                     try:
-                        file_download_path = os.path.join(bill_export_dir,
-                                                          f'{bill.id}-{service_type}-{meter_number}-'
-                                                          f'{bill.statement_year}-'
-                                                          f'{bill.statement_month}.pdf')
+                        filename = f'{bill.id}-{service_type}-{meter_number}-{bill.statement_year}' \
+                                   f'-{bill.statement_month}.pdf'.replace('/', '-')
+                        file_download_path = os.path.join(bill_export_dir, filename)
                         if os.path.exists(file_download_path):
                             print(f'Already downloaded bill {file_download_path}')
                             break

--- a/contxt/cli/commands/ems.py
+++ b/contxt/cli/commands/ems.py
@@ -1,14 +1,19 @@
 import csv
 import os
-from datetime import date, datetime
+from datetime import datetime
 
 import requests
 
 from contxt.models import Parsers
 from contxt.models.ems import ResourceType, UtilityUsage
 from contxt.models.iot import Window
-from contxt.services import (EmsService, FacilitiesService, IotService, LegacyFilesService,
-                             UtilitiesService)
+from contxt.services import (
+    EmsService,
+    FacilitiesService,
+    IotService,
+    LegacyFilesService,
+    UtilitiesService,
+)
 from contxt.utils.serializer import Serializer
 
 from .common import BaseParser, get_org_id
@@ -35,7 +40,9 @@ class Ems(BaseParser):
         md_parser.add_argument("start_time", type=Parsers.datetime, help="Start time")
         md_parser.add_argument("end_time", type=Parsers.datetime, help="End time")
         md_parser.add_argument(
-            '--download', action="store_true", help="Write main data to file in the data-exports directory"
+            "--download",
+            action="store_true",
+            help="Write main data to file in the data-exports directory",
         )
         md_parser.set_defaults(func=self._main_data)
 
@@ -61,9 +68,7 @@ class Ems(BaseParser):
         usage_parser.add_argument("resource_type", type=ResourceType, help="Type of resource")
         usage_parser.add_argument("start_date", type=Parsers.date, help="Start date")
         usage_parser.add_argument("end_date", type=Parsers.date, help="End date")
-        usage_parser.add_argument(
-            '--download', action="store_true", help="Download all usage data"
-        )
+        usage_parser.add_argument("--download", action="store_true", help="Download all usage data")
         usage_group = usage_parser.add_mutually_exclusive_group(required=True)
         usage_group.add_argument("-f" "--facility-ids", type=str, help="Facilities to get usage for")
         usage_group.add_argument("-g", "--org-id", help="Organization id")
@@ -79,10 +84,16 @@ class Ems(BaseParser):
         bills_parser.add_argument(
             "--resource_type", type=ResourceType, help="Filter by type of resource"
         )
-        bills_parser.add_argument('--from_date', help="Limit the date to fetch utility bills. Format: YYYY-MM-DD")
-        bills_parser.add_argument('--to_date', help="Limit the date to fetch utility bills. Format: YYYY-MM-DD")
         bills_parser.add_argument(
-            '--download', action="store_true", help="Download all PDF utility statements and their summaries"
+            "--from_date", help="Limit the date to fetch utility bills. Format: YYYY-MM-DD"
+        )
+        bills_parser.add_argument(
+            "--to_date", help="Limit the date to fetch utility bills. Format: YYYY-MM-DD"
+        )
+        bills_parser.add_argument(
+            "--download",
+            action="store_true",
+            help="Download all PDF utility statements and their summaries",
         )
         facility_group = bills_parser.add_mutually_exclusive_group(required=True)
         facility_group.add_argument("-f", "--facility-ids", type=str, help="Facilities to get bills for")
@@ -97,31 +108,29 @@ class Ems(BaseParser):
         main_services = ems_service.get_main_services(
             facility_id=args.facility_id, resource_type=args.resource_type
         )
-        print(Serializer.to_table(main_services, exclude_keys=['usage_field', 'demand_field']))
+        print(Serializer.to_table(main_services, exclude_keys=["usage_field", "demand_field"]))
 
     def _bills(self, args):
         utilities_service = UtilitiesService(args.auth)
         facilities_service = FacilitiesService(args.auth)
-        from_date = datetime.strptime(args.from_date, '%Y-%m-%d').date() if args.from_date else None
-        to_date = datetime.strptime(args.to_date, '%Y-%m-%d').date() if args.to_date else None
+        from_date = datetime.strptime(args.from_date, "%Y-%m-%d").date() if args.from_date else None
+        to_date = datetime.strptime(args.to_date, "%Y-%m-%d").date() if args.to_date else None
 
         # if facility ids are provided
         facility_ids_to_export = []
         if args.facility_ids is not None:
-            facility_ids_to_export = args.facility_ids.split(',')
+            facility_ids_to_export = args.facility_ids.split(",")
         else:
             org_id = get_org_id(args.org_name, args.auth)
             facility_objs = facilities_service.get_facilities(org_id)
             facility_ids_to_export = [f.id for f in facility_objs]
-            print(f'Exporting bills for {args.org_name} with {len(facility_ids_to_export)} facilities')
+            print(f"Exporting bills for {args.org_name} with {len(facility_ids_to_export)} facilities")
 
         for facility_id in facility_ids_to_export:
-            print(f'Exporting bills for facility {facility_id} from {from_date} to {to_date}')
+            print(f"Exporting bills for facility {facility_id} from {from_date} to {to_date}")
             bills = [
                 statement
-                for statement in utilities_service.get_statements(
-                    facility_id=facility_id
-                )
+                for statement in utilities_service.get_statements(facility_id=facility_id)
                 if (from_date is None or statement.interval_start > from_date)
                 and (to_date is None or statement.interval_end < to_date)
             ]
@@ -129,7 +138,7 @@ class Ems(BaseParser):
             if args.download:
                 self._download_pdf_statements(args, facility_id, bills, utilities_service)
             else:
-                print(Serializer.to_table(bills, sort_by='interval_start'))
+                print(Serializer.to_table(bills, sort_by="interval_start"))
 
     def _download_pdf_statements(self, args, facility_id, bills, utility_service):
         file_service = LegacyFilesService(args.auth)
@@ -138,15 +147,15 @@ class Ems(BaseParser):
         try:
             facility_obj = facilities_service.get_facility_with_id(facility_id)
         except requests.exceptions.HTTPError:
-            print('Facility not found')
+            print("Facility not found")
             return
 
-        print(f'Getting information for {facility_obj.name}')
+        print(f"Getting information for {facility_obj.name}")
 
         # build the directory structure
-        facility_export_dir = f'./data-exports/{facility_obj.name}/'
-        utilities_export_dir = os.path.join(facility_export_dir, 'utilities/')
-        bill_export_dir = os.path.join(utilities_export_dir, 'bill-pdfs/')
+        facility_export_dir = f"./data-exports/{facility_obj.name}/"
+        utilities_export_dir = os.path.join(facility_export_dir, "utilities/")
+        bill_export_dir = os.path.join(utilities_export_dir, "bill-pdfs/")
 
         # ensure the exports directory is created
         os.makedirs(bill_export_dir, exist_ok=True)
@@ -156,75 +165,88 @@ class Ems(BaseParser):
         accounts = {a.id: a for a in utility_service.get_accounts(facility_id)}
 
         bill_summary_data = []
-        unique_data_columns = ['account_number', 'meter_number', 'service_type', 'interval_start',
-                               'interval_end', 'assigned_statement_year', 'assigned_statement_month',
-                               'has_pdf_bill']
+        unique_data_columns = [
+            "account_number",
+            "meter_number",
+            "service_type",
+            "interval_start",
+            "interval_end",
+            "assigned_statement_year",
+            "assigned_statement_month",
+            "has_pdf_bill",
+        ]
 
         for idx, bill in enumerate(bills):
             # go get some more information about this bill regarding charges, kw, etc.
             raw_bill_data = utility_service.get_statement_data(bill.id)
-            '''
+            """
             Summary CSV:
-            account_number, meter_number, service_type, interval_start, interval_end, 
+            account_number, meter_number, service_type, interval_start, interval_end,
             assigned_statement_year, assigned_statement_month, has_pdf_bill, <charges_and_units> ->>
-            '''
+            """
 
             service_type = meters[bill.utility_meter_id].service_type
             meter_number = meters[bill.utility_meter_id].label
 
             # add the general bill metadata
             bill_metadata = {
-                'account_number': accounts[meters[bill.utility_meter_id].utility_account_id].label,
-                'meter_number': meter_number,
-                'service_type': service_type,
-                'interval_start': bill.interval_start,
-                'interval_end': bill.interval_end,
-                'assigned_statement_year': bill.statement_year,
-                'assigned_statement_month': bill.statement_month
+                "account_number": accounts[meters[bill.utility_meter_id].utility_account_id].label,
+                "meter_number": meter_number,
+                "service_type": service_type,
+                "interval_start": bill.interval_start,
+                "interval_end": bill.interval_end,
+                "assigned_statement_year": bill.statement_year,
+                "assigned_statement_month": bill.statement_month,
             }
 
             for row in raw_bill_data:
 
                 row_label = f"[Total] {row['node_label']} ({row['units']})"
                 # iterate over the bill data and add charge info to the metadata
-                bill_metadata[row_label] = row['value']
+                bill_metadata[row_label] = row["value"]
                 if row_label not in unique_data_columns:
                     unique_data_columns.append(row_label)
 
-                for child_charge in row['children']:
-                    child_label = f"[{row['node_label']}] {child_charge['node_label']} ({child_charge['units']})"
-                    bill_metadata[child_label] = child_charge['value']
+                for child_charge in row["children"]:
+                    child_label = (
+                        f"[{row['node_label']}] {child_charge['node_label']} ({child_charge['units']})"
+                    )
+                    bill_metadata[child_label] = child_charge["value"]
 
                     if child_label not in unique_data_columns:
                         unique_data_columns.append(child_label)
 
             # if a PDF of the bill is available, let's go fetch that
             if bill.file_id:
-                print(f'Downloading bill {idx+1} out of {len(bills)} for '
-                      f'{bill.statement_year}-{bill.statement_month}')
-                bill_metadata['has_pdf_bill'] = True
+                print(
+                    f"Downloading bill {idx+1} out of {len(bills)} for "
+                    f"{bill.statement_year}-{bill.statement_month}"
+                )
+                bill_metadata["has_pdf_bill"] = True
                 try:
                     file_read_endpoint = file_service.request_read_file(file_id=bill.file_id)
-                    filename = f'{bill.id}-{service_type}-{meter_number}-{bill.statement_year}' \
-                               f'-{bill.statement_month}.pdf'.replace('/', '-')
+                    filename = (
+                        f"{bill.id}-{service_type}-{meter_number}-{bill.statement_year}"
+                        f"-{bill.statement_month}.pdf".replace("/", "-")
+                    )
                     file_download_path = os.path.join(bill_export_dir, filename)
                     self._download_file(file_read_endpoint, file_download_path)
                 except requests.exceptions.HTTPError:
-                    print(f'Unable to read file with id {bill.file_id}')
+                    print(f"Unable to read file with id {bill.file_id}")
             else:
-                bill_metadata['has_pdf_bill'] = True
-                print(f'No PDF for bill starting: {bill.statement_year}-{bill.statement_month}')
+                bill_metadata["has_pdf_bill"] = True
+                print(f"No PDF for bill starting: {bill.statement_year}-{bill.statement_month}")
             bill_summary_data.append(bill_metadata)
 
         # Write all the metadata to a summary in a CSV file
-        summary_file_path = os.path.join(utilities_export_dir, f'summary.csv')
-        with open(summary_file_path, 'w') as csv_file:
+        summary_file_path = os.path.join(utilities_export_dir, "summary.csv")
+        with open(summary_file_path, "w") as csv_file:
             writer = csv.DictWriter(csv_file, fieldnames=unique_data_columns)
             writer.writeheader()
             for row in bill_summary_data:
                 for key in unique_data_columns:
                     if key not in row:
-                        row[key] = ''
+                        row[key] = ""
             writer.writerows(bill_summary_data)
 
     def _download_file(self, read_endpoint, local_file_path):
@@ -233,15 +255,15 @@ class Ems(BaseParser):
             try:
 
                 if os.path.exists(local_file_path):
-                    print(f'Already downloaded bill {local_file_path}')
+                    print(f"Already downloaded bill {local_file_path}")
                     break
                 r = requests.get(read_endpoint.temporary_url)
 
-                with open(local_file_path, 'wb') as f:
+                with open(local_file_path, "wb") as f:
                     f.write(r.content)
                 break
             except Exception as e:
-                print(f'Exception raised during download {e}')
+                print(f"Exception raised during download {e}")
                 try_count += 1
 
     def _main_data(self, args):
@@ -250,28 +272,31 @@ class Ems(BaseParser):
         facilities_service = FacilitiesService(args.auth)
 
         print(args.facility_ids)
-        for facility_id in args.facility_ids.split(','):
+        for facility_id in args.facility_ids.split(","):
 
             # get the facility object so we can make the directory more readable
             try:
                 facility_obj = facilities_service.get_facility_with_id(facility_id)
             except requests.exceptions.HTTPError:
-                print('Facility not found')
+                print("Facility not found")
                 continue
 
-            print(f'Getting interval data for {facility_obj.id} -> {facility_obj.name}')
+            print(f"Getting interval data for {facility_obj.id} -> {facility_obj.name}")
             try:
                 services = ems_service.get_main_services(
                     facility_id=facility_id, resource_type=args.resource_type
                 )
             except requests.exceptions.HTTPError:
-                print('Facility not found in EMS service')
+                print("Facility not found in EMS service")
                 continue
 
             data = {
                 service.name: iot_service.get_time_series_for_field(
-                    service.usage_field, start_time=args.start_time, end_time=args.end_time,
-                    window=Window.MINUTELY, per_page=5000
+                    service.usage_field,
+                    start_time=args.start_time,
+                    end_time=args.end_time,
+                    window=Window.MINUTELY,
+                    per_page=5000,
                 )
                 for service in services
             }
@@ -293,10 +318,7 @@ class Ems(BaseParser):
             for time, values in blended_data.items():
                 if (len(values)) == len(services):
                     try:
-                        summed_data.append({
-                            'time': time,
-                            'value': sum(values)
-                        })
+                        summed_data.append({"time": time, "value": sum(values)})
                     except Exception as e:
                         print(e)
                         print(values)
@@ -305,23 +327,22 @@ class Ems(BaseParser):
 
             if args.download and len(summed_data) > 0:
                 # build the directory structure
-                facility_export_dir = f'./data-exports/{facility_obj.name}/'
-                ems_export_dir = os.path.join(facility_export_dir, 'ems/')
+                facility_export_dir = f"./data-exports/{facility_obj.name}/"
+                ems_export_dir = os.path.join(facility_export_dir, "ems/")
 
                 # ensure the exports directory is created
                 os.makedirs(ems_export_dir, exist_ok=True)
 
                 # Write all the metadata to a summary in a CSV file
-                summary_file_path = os.path.join(ems_export_dir, f'minute_intervals.csv')
-                with open(summary_file_path, 'w') as csv_file:
-                    writer = csv.DictWriter(csv_file, fieldnames=['time', 'value'])
+                summary_file_path = os.path.join(ems_export_dir, "minute_intervals.csv")
+                with open(summary_file_path, "w") as csv_file:
+                    writer = csv.DictWriter(csv_file, fieldnames=["time", "value"])
                     writer.writeheader()
 
                     for data in summed_data:
                         writer.writerow(data)
             else:
                 print(Serializer.to_table(summed_data))
-
 
     def _util_spend(self, args):
         ems_service = EmsService(args.auth)
@@ -351,45 +372,43 @@ class Ems(BaseParser):
             }
             print(spend)
 
-    def _download_utility_usage(self, usage_data: UtilityUsage, args, facility_id,):
+    def _download_utility_usage(
+        self, usage_data: UtilityUsage, args, facility_id,
+    ):
         facilities_service = FacilitiesService(args.auth)
 
         # get the facility object so we can make the directory more readable
         try:
             facility_obj = facilities_service.get_facility_with_id(facility_id)
         except requests.exceptions.HTTPError:
-            print('Facility not found')
+            print("Facility not found")
             return
 
-        print(f'Writing information for {facility_obj.name}')
+        print(f"Writing information for {facility_obj.name}")
 
         # build the directory structure
-        facility_export_dir = f'./data-exports/{facility_obj.name}/'
-        ems_export_dir = os.path.join(facility_export_dir, 'ems/')
+        facility_export_dir = f"./data-exports/{facility_obj.name}/"
+        ems_export_dir = os.path.join(facility_export_dir, "ems/")
 
         # ensure the exports directory is created
         os.makedirs(ems_export_dir, exist_ok=True)
 
         # Write all the metadata to a summary in a CSV file
-        summary_file_path = os.path.join(ems_export_dir, f'usage_summary.csv')
-        with open(summary_file_path, 'w') as csv_file:
-            writer = csv.DictWriter(csv_file, fieldnames=['time', 'value'])
+        summary_file_path = os.path.join(ems_export_dir, "usage_summary.csv")
+        with open(summary_file_path, "w") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=["time", "value"])
             writer.writeheader()
 
             for data in usage_data.values:
                 if data.value is not None:
-                    writer.writerow({
-                        'time': data.event_time,
-                        'value': data.value
-                    })
-
+                    writer.writerow({"time": data.event_time, "value": data.value})
 
     def _utility_usage(self, args):
         ems_service = EmsService(args.auth)
         if args.f__facility_ids:
             print(args.f__facility_ids)
-            for facility_id in args.f__facility_ids.split(','):
-                print(f'Getting Utility usage for facility {facility_id}')
+            for facility_id in args.f__facility_ids.split(","):
+                print(f"Getting Utility usage for facility {facility_id}")
                 # Get facility usage
                 try:
                     usage = ems_service.get_ems_usage(
@@ -400,12 +419,12 @@ class Ems(BaseParser):
                         end_date=args.end_date,
                         pro_forma=args.pro_forma,
                     )
-                    if (args.download):
+                    if args.download:
                         self._download_utility_usage(usage, args, facility_id)
                     else:
                         print(Serializer.to_pretty_cli(usage))
                 except requests.exceptions.HTTPError:
-                    print('Facility not found')
+                    print("Facility not found")
 
         else:
             # Get organization usage

--- a/contxt/cli/commands/ems.py
+++ b/contxt/cli/commands/ems.py
@@ -70,7 +70,7 @@ class Ems(BaseParser):
         usage_parser.add_argument("end_date", type=Parsers.date, help="End date")
         usage_parser.add_argument("--download", action="store_true", help="Download all usage data")
         usage_group = usage_parser.add_mutually_exclusive_group(required=True)
-        usage_group.add_argument("-f" "--facility-ids", type=str, help="Facilities to get usage for")
+        usage_group.add_argument("-f", "--facility-ids", type=str, help="Facilities to get usage for")
         usage_group.add_argument("-g", "--org-id", help="Organization id")
         usage_group.add_argument("-n", "--org-name", help="Organization name")
         usage_parser.add_argument("-o", "--output", help="Filename to save data (csv)")
@@ -82,13 +82,13 @@ class Ems(BaseParser):
         # Utility Bills
         bills_parser = _subparsers.add_parser("bills", help="Get Utility Bills")
         bills_parser.add_argument(
-            "--resource_type", type=ResourceType, help="Filter by type of resource"
+            "--resource-type", type=ResourceType, help="Filter by type of resource"
         )
         bills_parser.add_argument(
-            "--from_date", help="Limit the date to fetch utility bills. Format: YYYY-MM-DD"
+            "--from-date", help="Limit the date to fetch utility bills. Format: YYYY-MM-DD"
         )
         bills_parser.add_argument(
-            "--to_date", help="Limit the date to fetch utility bills. Format: YYYY-MM-DD"
+            "--to-date", help="Limit the date to fetch utility bills. Format: YYYY-MM-DD"
         )
         bills_parser.add_argument(
             "--download",

--- a/contxt/cli/commands/ems.py
+++ b/contxt/cli/commands/ems.py
@@ -1,7 +1,12 @@
 from contxt.models import Parsers
-from contxt.models.ems import ResourceType
-from contxt.services import EmsService, FacilitiesService, IotService
+from contxt.models.ems import ResourceType, UtilityUsage
+from contxt.services import EmsService, FacilitiesService, IotService, UtilitiesService, \
+    LegacyFilesService
+from contxt.utils.serializer import Serializer
 
+import requests
+import os
+import csv
 from .common import BaseParser, get_org_id
 
 
@@ -49,8 +54,11 @@ class Ems(BaseParser):
         usage_parser.add_argument("resource_type", type=ResourceType, help="Type of resource")
         usage_parser.add_argument("start_date", type=Parsers.date, help="Start date")
         usage_parser.add_argument("end_date", type=Parsers.date, help="End date")
+        usage_parser.add_argument(
+            '--download', action="store_true", help="Download all usage data"
+        )
         usage_group = usage_parser.add_mutually_exclusive_group(required=True)
-        usage_group.add_argument("-f", "--facility-id", type=int, help="Facility id")
+        usage_group.add_argument("-f" "--facility-ids", type=str, help="Facilities to get usage for")
         usage_group.add_argument("-g", "--org-id", help="Organization id")
         usage_group.add_argument("-n", "--org-name", help="Organization name")
         usage_parser.add_argument("-o", "--output", help="Filename to save data (csv)")
@@ -59,6 +67,17 @@ class Ems(BaseParser):
         )
         usage_parser.set_defaults(func=self._utility_usage)
 
+        # Utility Bills
+        bills_parser = _subparsers.add_parser("bills", help="Get Utility Bills")
+        bills_parser.add_argument("facility_ids", type=str, help="Facility to get bills for")
+        bills_parser.add_argument(
+            "--resource_type", type=ResourceType, help="Filter by type of resource"
+        )
+        bills_parser.add_argument(
+            '--download', action="store_true", help="Download all PDF utility statements and their summaries"
+        )
+        bills_parser.set_defaults(func=self._bills)
+
         return parser
 
     def _mains(self, args):
@@ -66,7 +85,118 @@ class Ems(BaseParser):
         main_services = ems_service.get_main_services(
             facility_id=args.facility_id, resource_type=args.resource_type
         )
-        print(main_services)
+        print(Serializer.to_table(main_services, exclude_keys=['usage_field', 'demand_field']))
+
+    def _bills(self, args):
+        utilities_service = UtilitiesService(args.auth)
+        print(args.facility_ids)
+        for facility_id in args.facility_ids.split(','):
+            print(f'Exporting bills for facility {facility_id}')
+            bills = utilities_service.get_statements(facility_id=facility_id)
+            if args.download:
+                self._download_pdf_statements(args, facility_id, bills, utilities_service)
+            else:
+                print(Serializer.to_table(bills, sort_by='interval_start'))
+
+    def _download_pdf_statements(self, args, facility_id, bills, utility_service):
+        file_service = LegacyFilesService(args.auth)
+        facilities_service = FacilitiesService(args.auth)
+
+        # get the facility object so we can make the directory more readable
+        try:
+            facility_obj = facilities_service.get_facility_with_id(facility_id)
+        except requests.exceptions.HTTPError:
+            print('Facility not found')
+            return
+
+        print(f'Getting information for {facility_obj.name}')
+
+        # build the directory structure
+        facility_export_dir = f'./data-exports/{facility_obj.name}/'
+        utilities_export_dir = os.path.join(facility_export_dir, 'utilities/')
+        bill_export_dir = os.path.join(utilities_export_dir, 'bill-pdfs/')
+
+        # ensure the exports directory is created
+        os.makedirs(bill_export_dir, exist_ok=True)
+
+        # get the account and meter information so we can map it from IDs to use in our export
+        meters = {m.id: m for m in utility_service.get_meters(facility_id)}
+        accounts = {a.id: a for a in utility_service.get_accounts(facility_id)}
+
+        bill_summary_data = []
+        unique_data_columns = ['account_number', 'meter_number', 'service_type', 'interval_start',
+                               'interval_end', 'assigned_statement_year', 'assigned_statement_month',
+                               'has_pdf_bill']
+
+        for idx, bill in enumerate(bills):
+            # go get some more information about this bill regarding charges, kw, etc.
+            raw_bill_data = utility_service.get_statement_data(bill.id)
+            '''
+            Summary CSV:
+            account_number, meter_number, service_type, interval_start, interval_end, 
+            assigned_statement_year, assigned_statement_month, has_pdf_bill, <charges_and_units> ->>
+            '''
+            # add the general bill metadata
+            bill_metadata = {
+                'account_number': accounts[meters[bill.utility_meter_id].utility_account_id].label,
+                'meter_number': meters[bill.utility_meter_id].label,
+                'service_type': meters[bill.utility_meter_id].service_type,
+                'interval_start': bill.interval_start,
+                'interval_end': bill.interval_end,
+                'assigned_statement_year': bill.statement_year,
+                'assigned_statement_month': bill.statement_month
+            }
+
+            for row in raw_bill_data:
+
+                row_label = f"[Total] {row['node_label']} ({row['units']})"
+                # iterate over the bill data and add charge info to the metadata
+                bill_metadata[row_label] = row['value']
+                if row_label not in unique_data_columns:
+                    unique_data_columns.append(row_label)
+
+                for child_charge in row['children']:
+                    child_label = f"[{row['node_label']}] {child_charge['node_label']} ({child_charge['units']})"
+                    bill_metadata[child_label] = child_charge['value']
+
+                    if child_label not in unique_data_columns:
+                        unique_data_columns.append(child_label)
+
+            # if a PDF of the bill is available, let's go fetch that
+            if bill.file_id:
+                print(f'Downloading bill {idx+1} out of {len(bills)} for '
+                      f'{bill.statement_year}-{bill.statement_month}')
+                bill_metadata['has_pdf_bill'] = True
+                file_read = file_service.request_read_file(file_id=bill.file_id)
+                try_count = 0
+                while try_count < 3:
+                    try:
+                        r = requests.get(file_read.temporary_url)
+                        file_download_path = os.path.join(bill_export_dir,
+                                                          f'utility-bill-{bill.statement_year}-'
+                                                          f'{bill.statement_month}.pdf')
+                        with open(file_download_path, 'wb') as f:
+                            f.write(r.content)
+                        break
+                    except Exception as e:
+                        print(f'Exception raised during download {e}')
+                        try_count += 1
+
+            else:
+                bill_metadata['has_pdf_bill'] = True
+                print(f'No PDF for bill starting: {bill.statement_year}-{bill.statement_month}')
+            bill_summary_data.append(bill_metadata)
+
+        # Write all the metadata to a summary in a CSV file
+        summary_file_path = os.path.join(utilities_export_dir, f'summary.csv')
+        with open(summary_file_path, 'w') as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=unique_data_columns)
+            writer.writeheader()
+            for row in bill_summary_data:
+                for key in unique_data_columns:
+                    if key not in row:
+                        row[key] = ''
+            writer.writerows(bill_summary_data)
 
     def _main_data(self, args):
         ems_service = EmsService(args.auth)
@@ -110,18 +240,62 @@ class Ems(BaseParser):
             }
             print(spend)
 
+    def _download_utility_usage(self, usage_data: UtilityUsage, args, facility_id,):
+        facilities_service = FacilitiesService(args.auth)
+
+        # get the facility object so we can make the directory more readable
+        try:
+            facility_obj = facilities_service.get_facility_with_id(facility_id)
+        except requests.exceptions.HTTPError:
+            print('Facility not found')
+            return
+
+        print(f'Writing information for {facility_obj.name}')
+
+        # build the directory structure
+        facility_export_dir = f'./data-exports/{facility_obj.name}/'
+        ems_export_dir = os.path.join(facility_export_dir, 'ems/')
+
+        # ensure the exports directory is created
+        os.makedirs(ems_export_dir, exist_ok=True)
+
+        # Write all the metadata to a summary in a CSV file
+        summary_file_path = os.path.join(ems_export_dir, f'usage_summary.csv')
+        with open(summary_file_path, 'w') as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=['time', 'value'])
+            writer.writeheader()
+
+            for data in usage_data.values:
+                if data.value is not None:
+                    writer.writerow({
+                        'time': data.event_time,
+                        'value': data.value
+                    })
+
+
     def _utility_usage(self, args):
         ems_service = EmsService(args.auth)
-        if args.facility_id:
-            # Get facility usage
-            usage = ems_service.get_monthly_utility_usage(
-                facility_id=args.facility_id,
-                resource_type=args.resource_type,
-                start_date=args.start_date,
-                end_date=args.end_date,
-                pro_forma=args.pro_forma,
-            )
-            print(usage)
+        if args.f__facility_ids:
+            print(args.f__facility_ids)
+            for facility_id in args.f__facility_ids.split(','):
+                print(f'Getting Utility usage for facility {facility_id}')
+                # Get facility usage
+                try:
+                    usage = ems_service.get_ems_usage(
+                        facility_id=facility_id,
+                        interval=args.interval,
+                        resource_type=args.resource_type,
+                        start_date=args.start_date,
+                        end_date=args.end_date,
+                        pro_forma=args.pro_forma,
+                    )
+                    if (args.download):
+                        self._download_utility_usage(usage, args, facility_id)
+                    else:
+                        print(Serializer.to_pretty_cli(usage))
+                except requests.exceptions.HTTPError:
+                    print('Facility not found')
+
         else:
             # Get organization usage
             organization_id = args.org_id or get_org_id(args.org_name, args.auth)

--- a/contxt/cli/commands/projects.py
+++ b/contxt/cli/commands/projects.py
@@ -1,4 +1,3 @@
-from contxt.models.contxt import Organization
 from contxt.services import ContxtService
 from contxt.utils.serializer import Serializer
 
@@ -39,7 +38,7 @@ class Projects(BaseParser):
     def _get_projects(self, args):
         contxt_service = ContxtService(args.auth)
         projects = contxt_service.get_projects()
-        print(Serializer.to_table(projects, sort_by='created_at'))
+        print(Serializer.to_table(projects, sort_by="created_at"))
 
     def _get_services(self, args):
         contxt_service = ContxtService(args.auth)
@@ -49,6 +48,5 @@ class Projects(BaseParser):
     def _get_edge_nodes(self, args):
         org_id = args.org_id or get_org_id(args.org_name, args.auth)
         contxt_service = ContxtService(args.auth)
-        nodes = contxt_service.get_edge_nodes(organization_id=org_id,
-                                              project_id=args.project_id)
+        nodes = contxt_service.get_edge_nodes(organization_id=org_id, project_id=args.project_id)
         print(Serializer.to_table(nodes))

--- a/contxt/cli/commands/projects.py
+++ b/contxt/cli/commands/projects.py
@@ -1,0 +1,54 @@
+from contxt.models.contxt import Organization
+from contxt.services import ContxtService
+from contxt.utils.serializer import Serializer
+
+from .common import BaseParser, get_org_id
+
+
+class Projects(BaseParser):
+    def _init_parser(self, subparsers):
+        parser = subparsers.add_parser("projects", help="Contxt Projects")
+        parser.set_defaults(func=self._get_projects)
+        _subparsers = parser.add_subparsers(title="subcommands", dest="subcommand")
+
+        # Get Project
+        project_parser = _subparsers.add_parser("get", help="Get a project")
+        project_parser.add_argument("project_id", help="Project ID")
+        project_parser.set_defaults(func=self._get_project)
+
+        # Services
+        services_parser = _subparsers.add_parser("get-services", help="Get services for a project")
+        services_parser.add_argument("project_id", help="Project ID")
+        services_parser.set_defaults(func=self._get_services)
+
+        # Edge Nodes
+        edge_nodes_parser = _subparsers.add_parser("get-edge-nodes", help="Get edge nodes for a project")
+        edge_nodes_parser.add_argument("project_id", help="Project ID")
+        org_group = edge_nodes_parser.add_mutually_exclusive_group(required=True)
+        org_group.add_argument("-i", "--org-id", help="Organization id")
+        org_group.add_argument("-n", "--org-name", help="Organization name")
+        edge_nodes_parser.set_defaults(func=self._get_edge_nodes)
+
+        return parser
+
+    def _get_project(self, args):
+        contxt_service = ContxtService(args.auth)
+        project = contxt_service.get_project(args.project_id)
+        print(Serializer.to_pretty_cli(project))
+
+    def _get_projects(self, args):
+        contxt_service = ContxtService(args.auth)
+        projects = contxt_service.get_projects()
+        print(Serializer.to_table(projects, sort_by='created_at'))
+
+    def _get_services(self, args):
+        contxt_service = ContxtService(args.auth)
+        services = contxt_service.get_services(args.project_id)
+        print(Serializer.to_table(services))
+
+    def _get_edge_nodes(self, args):
+        org_id = args.org_id or get_org_id(args.org_name, args.auth)
+        contxt_service = ContxtService(args.auth)
+        nodes = contxt_service.get_edge_nodes(organization_id=org_id,
+                                              project_id=args.project_id)
+        print(Serializer.to_table(nodes))

--- a/contxt/cli/commands/service.py
+++ b/contxt/cli/commands/service.py
@@ -1,8 +1,7 @@
-from contxt.models.contxt import Organization
 from contxt.services import ContxtService
 from contxt.utils.serializer import Serializer
 
-from .common import BaseParser, get_org_id
+from .common import BaseParser
 
 
 class Services(BaseParser):

--- a/contxt/cli/commands/service.py
+++ b/contxt/cli/commands/service.py
@@ -1,0 +1,29 @@
+from contxt.models.contxt import Organization
+from contxt.services import ContxtService
+from contxt.utils.serializer import Serializer
+
+from .common import BaseParser, get_org_id
+
+
+class Services(BaseParser):
+    def _init_parser(self, subparsers):
+        parser = subparsers.add_parser("services", help="Contxt Services")
+        parser.set_defaults(func=self._get_services)
+        _subparsers = parser.add_subparsers(title="subcommands", dest="subcommand")
+
+        # Get Service
+        service_parser = _subparsers.add_parser("get", help="Get a service")
+        service_parser.add_argument("service_id", help="Service ID")
+        service_parser.set_defaults(func=self._get_service)
+
+        return parser
+
+    def _get_service(self, args):
+        contxt_service = ContxtService(args.auth)
+        service = contxt_service.get_service(args.service_id)
+        print(Serializer.to_pretty_cli(service))
+
+    def _get_services(self, args):
+        contxt_service = ContxtService(args.auth)
+        services = contxt_service.get_services()
+        print(Serializer.to_table(services))

--- a/contxt/cli/main.py
+++ b/contxt/cli/main.py
@@ -5,7 +5,7 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from contxt import __version__
 from contxt.auth.cli import CliAuth
 
-from .commands import Assets, Auth, Bus, Contxt, Ems, Iot
+from .commands import Assets, Auth, Bus, Contxt, Ems, Iot, Projects
 
 
 def create_parser() -> ArgumentParser:
@@ -16,7 +16,7 @@ def create_parser() -> ArgumentParser:
 
     # Register subparsers
     parsers = parser.add_subparsers(title="subcommands", dest="command")
-    [cls(parsers) for cls in [Assets, Auth, Bus, Contxt, Ems, Iot]]
+    [cls(parsers) for cls in [Assets, Auth, Bus, Contxt, Ems, Iot, Projects]]
     return parser
 
 

--- a/contxt/cli/main.py
+++ b/contxt/cli/main.py
@@ -5,7 +5,7 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from contxt import __version__
 from contxt.auth.cli import CliAuth
 
-from .commands import Assets, Auth, Bus, Contxt, Ems, Iot, Projects
+from .commands import Assets, Auth, Bus, Contxt, Ems, Iot, Projects, Services
 
 
 def create_parser() -> ArgumentParser:
@@ -16,7 +16,7 @@ def create_parser() -> ArgumentParser:
 
     # Register subparsers
     parsers = parser.add_subparsers(title="subcommands", dest="command")
-    [cls(parsers) for cls in [Assets, Auth, Bus, Contxt, Ems, Iot, Projects]]
+    [cls(parsers) for cls in [Assets, Auth, Bus, Contxt, Ems, Iot, Projects, Services]]
     return parser
 
 

--- a/contxt/models/contxt.py
+++ b/contxt/models/contxt.py
@@ -173,11 +173,105 @@ class User(ApiObject):
 
 
 @dataclass
+class ServiceEnvironmentVariable(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id"),
+        ApiField("service_id"),
+        ApiField("environment"),
+        ApiField("key"),
+        ApiField("value"),
+        ApiField("is_protected"),
+        ApiField("config_map_value_id"),
+        ApiField("created_at", data_type=Parsers.datetime),
+        ApiField("updated_at", data_type=Parsers.datetime)
+    )
+
+    id: int
+    service_id: int
+    environment: str
+    key: str
+    value: str
+    is_protected: bool
+    config_map_value_id: int
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+@dataclass
+class Domain(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id"),
+        ApiField("name"),
+        ApiField("cert_name"),
+        ApiField("created_at", data_type=Parsers.datetime),
+        ApiField("updated_at", data_type=Parsers.datetime)
+    )
+
+    id: int
+    name: str
+    cert_name: str
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+@dataclass
+class Frontend(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id"),
+        ApiField("service_id"),
+        ApiField("vhost"),
+        ApiField("force_ssl"),
+        ApiField("domain_id"),
+        ApiField("domain", data_type=Domain),
+        ApiField("created_at", data_type=Parsers.datetime),
+        ApiField("updated_at", data_type=Parsers.datetime)
+    )
+
+    id: int
+    service_id: int
+    vhost: str
+    force_ssl: bool
+    domain_id: int
+    domain: Optional[Domain] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+@dataclass
+class Image(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id"),
+        ApiField("provider"),
+        ApiField("image_name"),
+        ApiField("image_tag_id"),
+        ApiField("image_secret_id"),
+        ApiField("created_at", data_type=Parsers.datetime),
+        ApiField("updated_at", data_type=Parsers.datetime)
+    )
+
+    id: int
+    provider: str
+    image_name: str
+    image_tag_id: str
+    image_secret_id: int
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+@dataclass
 class Service(ApiObject):
     _api_fields: ClassVar = (
         ApiField("id"),
         ApiField("name"),
         ApiField("description"),
+        ApiField("descriptor"),
+        ApiField("client_id"),
+        ApiField("command"),
+        ApiField("arguments"),
+        ApiField("last_deployed_at"),
+        ApiField("last_configured_at"),
+        ApiField("service_env_variables", data_type=ServiceEnvironmentVariable),
+        ApiField("frontend", data_type=Frontend),
+        ApiField("image", data_type=Image),
         ApiField("service_type"),
         ApiField("created_at", data_type=Parsers.datetime)
     )
@@ -185,7 +279,16 @@ class Service(ApiObject):
     id: int
     name: str
     description: str
+    descriptor: str
+    client_id: str
+    command: str
+    arguments: str
+    last_deployed_at: Optional[datetime]
+    last_configured_at: Optional[datetime]
     service_type: str
+    service_env_variables: Optional[List[ServiceEnvironmentVariable]] = None
+    frontend: Optional[Frontend] = None
+    image: Optional[Image] = None
     created_at: Optional[datetime] = None
 
 

--- a/contxt/models/contxt.py
+++ b/contxt/models/contxt.py
@@ -302,7 +302,7 @@ class Project(ApiObject):
         ApiField("type"),
         ApiField("created_at", data_type=Parsers.datetime),
         ApiField("Roles", attr_key="roles", data_type=Role, optional=True),
-        ApiField("Services", attr_key="Services", data_type=Service, optional=True),
+        ApiField("Services", attr_key="services", data_type=Service, optional=True),
     )
 
     id: int
@@ -310,7 +310,7 @@ class Project(ApiObject):
     description: str
     type: str
     roles: Optional[List[Role]] = None
-    Services: Optional[List[Service]] = None
+    services: Optional[List[Service]] = None
     created_at: Optional[datetime] = None
 
 

--- a/contxt/models/contxt.py
+++ b/contxt/models/contxt.py
@@ -183,7 +183,7 @@ class ServiceEnvironmentVariable(ApiObject):
         ApiField("is_protected"),
         ApiField("config_map_value_id"),
         ApiField("created_at", data_type=Parsers.datetime),
-        ApiField("updated_at", data_type=Parsers.datetime)
+        ApiField("updated_at", data_type=Parsers.datetime),
     )
 
     id: int
@@ -196,6 +196,7 @@ class ServiceEnvironmentVariable(ApiObject):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
+
 @dataclass
 class Domain(ApiObject):
     _api_fields: ClassVar = (
@@ -203,7 +204,7 @@ class Domain(ApiObject):
         ApiField("name"),
         ApiField("cert_name"),
         ApiField("created_at", data_type=Parsers.datetime),
-        ApiField("updated_at", data_type=Parsers.datetime)
+        ApiField("updated_at", data_type=Parsers.datetime),
     )
 
     id: int
@@ -223,7 +224,7 @@ class Frontend(ApiObject):
         ApiField("domain_id"),
         ApiField("domain", data_type=Domain),
         ApiField("created_at", data_type=Parsers.datetime),
-        ApiField("updated_at", data_type=Parsers.datetime)
+        ApiField("updated_at", data_type=Parsers.datetime),
     )
 
     id: int
@@ -245,7 +246,7 @@ class Image(ApiObject):
         ApiField("image_tag_id"),
         ApiField("image_secret_id"),
         ApiField("created_at", data_type=Parsers.datetime),
-        ApiField("updated_at", data_type=Parsers.datetime)
+        ApiField("updated_at", data_type=Parsers.datetime),
     )
 
     id: int
@@ -273,7 +274,7 @@ class Service(ApiObject):
         ApiField("frontend", data_type=Frontend, optional=True),
         ApiField("image", data_type=Image, optional=True),
         ApiField("service_type"),
-        ApiField("created_at", data_type=Parsers.datetime)
+        ApiField("created_at", data_type=Parsers.datetime),
     )
 
     id: int
@@ -301,7 +302,7 @@ class Project(ApiObject):
         ApiField("type"),
         ApiField("created_at", data_type=Parsers.datetime),
         ApiField("Roles", attr_key="roles", data_type=Role, optional=True),
-        ApiField("Services", attr_key="Services", data_type=Service, optional=True)
+        ApiField("Services", attr_key="Services", data_type=Service, optional=True),
     )
 
     id: int
@@ -322,7 +323,7 @@ class EdgeNode(ApiObject):
         ApiField("organization_id"),
         ApiField("description"),
         ApiField("client_id"),
-        ApiField("created_at", data_type=Parsers.datetime)
+        ApiField("created_at", data_type=Parsers.datetime),
     )
 
     id: int
@@ -332,4 +333,3 @@ class EdgeNode(ApiObject):
     description: str
     client_id: str
     created_at: Optional[datetime] = None
-

--- a/contxt/models/contxt.py
+++ b/contxt/models/contxt.py
@@ -269,9 +269,9 @@ class Service(ApiObject):
         ApiField("arguments"),
         ApiField("last_deployed_at"),
         ApiField("last_configured_at"),
-        ApiField("service_env_variables", data_type=ServiceEnvironmentVariable),
-        ApiField("frontend", data_type=Frontend),
-        ApiField("image", data_type=Image),
+        ApiField("service_env_variables", data_type=ServiceEnvironmentVariable, optional=True),
+        ApiField("frontend", data_type=Frontend, optional=True),
+        ApiField("image", data_type=Image, optional=True),
         ApiField("service_type"),
         ApiField("created_at", data_type=Parsers.datetime)
     )

--- a/contxt/models/contxt.py
+++ b/contxt/models/contxt.py
@@ -129,7 +129,7 @@ class Role(ApiObject):
         ApiField("name"),
         ApiField("description"),
         ApiField("organization_id"),
-        ApiField("UserRole", attr_key="user_role", data_type=UserRole),
+        ApiField("UserRole", attr_key="user_role", data_type=UserRole, optional=True),
         ApiField("created_at", data_type=Parsers.datetime),
         ApiField("updated_at", data_type=Parsers.datetime),
     )
@@ -137,7 +137,7 @@ class Role(ApiObject):
     name: str
     description: str
     organization_id: str
-    user_role: UserRole
+    user_role: Optional[UserRole] = None
     id: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -151,9 +151,9 @@ class User(ApiObject):
         ApiField("last_name"),
         ApiField("email"),
         ApiField("is_activated", data_type=bool),
-        ApiField("Roles", attr_key="roles", data_type=Role),
+        ApiField("Roles", attr_key="roles", data_type=Role, optional=True),
         ApiField("is_superuser"),
-        ApiField("organizations", data_type=Organization),
+        ApiField("organizations", data_type=Organization, optional=True),
         ApiField("phone_number"),
         ApiField("created_at", data_type=Parsers.datetime),
         ApiField("updated_at", data_type=Parsers.datetime),
@@ -165,8 +165,68 @@ class User(ApiObject):
     phone_number: str
     is_activated: bool
     is_superuser: bool
-    roles: List[Role]
-    organizations: List[Organization]
+    roles: Optional[List[Role]] = None
+    organizations: Optional[List[Organization]] = None
     id: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+
+
+@dataclass
+class Service(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id"),
+        ApiField("name"),
+        ApiField("description"),
+        ApiField("service_type"),
+        ApiField("created_at", data_type=Parsers.datetime)
+    )
+
+    id: int
+    name: str
+    description: str
+    service_type: str
+    created_at: Optional[datetime] = None
+
+
+@dataclass
+class Project(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id"),
+        ApiField("name"),
+        ApiField("description"),
+        ApiField("type"),
+        ApiField("created_at", data_type=Parsers.datetime),
+        ApiField("Roles", attr_key="roles", data_type=Role, optional=True),
+        ApiField("Services", attr_key="Services", data_type=Service, optional=True)
+    )
+
+    id: int
+    name: str
+    description: str
+    type: str
+    roles: Optional[List[Role]] = None
+    Services: Optional[List[Service]] = None
+    created_at: Optional[datetime] = None
+
+
+@dataclass
+class EdgeNode(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id"),
+        ApiField("name"),
+        ApiField("stack_id"),
+        ApiField("organization_id"),
+        ApiField("description"),
+        ApiField("client_id"),
+        ApiField("created_at", data_type=Parsers.datetime)
+    )
+
+    id: int
+    name: str
+    stack_id: int
+    organization_id: str
+    description: str
+    client_id: str
+    created_at: Optional[datetime] = None
+

--- a/contxt/models/ems.py
+++ b/contxt/models/ems.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, date
 from enum import Enum
 from typing import ClassVar, Dict, List, Optional
 
@@ -68,14 +68,13 @@ class Facility(ApiObject):
 @dataclass
 class UtilityPeriod(ApiObject):
     _api_fields: ClassVar = (
-        ApiField("date"),
-        ApiField("value"),
-        ApiField("pro_forma_date", optional=True),
+        ApiField("event_time", data_type=Parsers.datetime),
+        ApiField("value", data_type=int),
     )
 
-    date: str
-    value: str
-    pro_forma_date: Optional[str] = None
+    event_time: datetime
+    value: int
+    #pro_forma_date: Optional[str] = None
 
 
 UtilitySpendPeriod = UtilityPeriod
@@ -109,7 +108,7 @@ class UtilityUsage(ApiObject):
 
     type: str
     unit: str
-    values: Dict
+    values: List[UtilityUsagePeriod]
 
     @property
     def periods(self):
@@ -166,3 +165,86 @@ class UtilityContract(ApiObject):
     utility_contract_reminders: List[UtilityContractReminder]
     report_event_id: str
     report_event: Event
+
+
+@dataclass
+class UtilityStatement(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id", data_type=int),
+        ApiField("utility_meter_id", data_type=int),
+        ApiField("statement_month", data_type=str),
+        ApiField("statement_year", data_type=str),
+        ApiField("interval_start", data_type=Parsers.date),
+        ApiField("interval_end", data_type=Parsers.date),
+        ApiField("file_id", data_type=int),
+        ApiField("is_validated", data_type=bool),
+        ApiField("pm_id", data_type=int),
+        ApiField("uploaded_to_pm", data_type=bool),
+        ApiField("created_at", data_type=Parsers.datetime),
+        ApiField("updated_at", data_type=Parsers.datetime),
+    )
+
+    id: int
+    utility_meter_id: int
+    statement_month: str
+    statement_year: str
+    interval_start: date
+    interval_end: date
+    file_id: int
+    is_validated: bool
+    pm_id: int
+    uploaded_to_pm: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass
+class UtilityMeter(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id", data_type=int),
+        ApiField("label", data_type=str),
+        ApiField("utility_account_id", data_type=int),
+        ApiField("building_id", data_type=int),
+        ApiField("service_type", data_type=str),
+        ApiField("logical_meter_id", data_type=str),
+        ApiField("meter_number", data_type=str),
+        ApiField("active_start", data_type=Parsers.date),
+        ApiField("active_end", data_type=Parsers.date),
+        ApiField("pm_id", data_type=int),
+        ApiField("created_at", data_type=Parsers.datetime),
+        ApiField("updated_at", data_type=Parsers.datetime),
+    )
+
+    id: int
+    label: str
+    utility_account_id: int
+    building_id: int
+    service_type: str
+    logical_meter_id: str
+    meter_number: str
+    active_start: date
+    active_end: date
+    pm_id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass
+class UtilityAccount(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id", data_type=int),
+        ApiField("logical_account_id", data_type=str),
+        ApiField("facility_id", data_type=int),
+        ApiField("account_number", data_type=str),
+        ApiField("label", data_type=str),
+        ApiField("created_at", data_type=Parsers.datetime),
+        ApiField("updated_at", data_type=Parsers.datetime),
+    )
+
+    id: int
+    logical_account_id: int
+    facility_id: int
+    account_number: str
+    label: str
+    created_at: datetime
+    updated_at: datetime

--- a/contxt/models/ems.py
+++ b/contxt/models/ems.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from datetime import datetime, date
+from datetime import date, datetime
 from enum import Enum
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar, List
 
 from . import ApiField, ApiObject, Parsers
 from .events import Event
@@ -74,7 +74,7 @@ class UtilityPeriod(ApiObject):
 
     event_time: datetime
     value: int
-    #pro_forma_date: Optional[str] = None
+    # pro_forma_date: Optional[str] = None
 
 
 UtilitySpendPeriod = UtilityPeriod

--- a/contxt/models/files.py
+++ b/contxt/models/files.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import ClassVar, Optional
+
+from . import ApiField, ApiObject, Parsers
+
+
+@dataclass
+class FileRead(ApiObject):
+    _api_fields: ClassVar = (
+        ApiField("id"),
+        ApiField("file_id"),
+        ApiField("temporary_url"),
+        ApiField("expires_at"),
+        ApiField("action"),
+        ApiField("created_at", data_type=Parsers.datetime),
+        ApiField("updated_at", data_type=Parsers.datetime),
+        ApiField("file_created_at", data_type=Parsers.datetime),
+    )
+
+    id: int
+    file_id: int
+    temporary_url: str
+    expires_at: datetime
+    action: str
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    file_created_at: Optional[datetime] = None

--- a/contxt/services/__init__.py
+++ b/contxt/services/__init__.py
@@ -1,5 +1,6 @@
 """API clients"""
 
+# flake8: noqa
 from .assets import AssetsService
 from .auth import AuthService
 from .bus import MessageBusService
@@ -12,19 +13,3 @@ from .health import HealthService
 from .iot import IotDataService, IotService
 from .ngest import NgestService
 from .utilities import UtilitiesService
-
-__all__ = [
-    "AssetsService",
-    "AuthService",
-    "MessageBusService",
-    "ContxtService",
-    "EmsService",
-    "EventsService",
-    "FacilitiesService",
-    "HealthService",
-    "IotService",
-    "IotDataService",
-    "NgestService",
-    "UtilitiesService",
-    "LegacyFilesService",
-]

--- a/contxt/services/__init__.py
+++ b/contxt/services/__init__.py
@@ -10,6 +10,8 @@ from .facilities import FacilitiesService
 from .health import HealthService
 from .iot import IotDataService, IotService
 from .ngest import NgestService
+from .utilities import UtilitiesService
+from .files import LegacyFilesService
 
 __all__ = [
     "AssetsService",
@@ -23,4 +25,6 @@ __all__ = [
     "IotService",
     "IotDataService",
     "NgestService",
+    "UtilitiesService",
+    "LegacyFilesService"
 ]

--- a/contxt/services/__init__.py
+++ b/contxt/services/__init__.py
@@ -7,11 +7,11 @@ from .contxt import ContxtService
 from .ems import EmsService
 from .events import EventsService
 from .facilities import FacilitiesService
+from .files import LegacyFilesService
 from .health import HealthService
 from .iot import IotDataService, IotService
 from .ngest import NgestService
 from .utilities import UtilitiesService
-from .files import LegacyFilesService
 
 __all__ = [
     "AssetsService",
@@ -26,5 +26,5 @@ __all__ = [
     "IotDataService",
     "NgestService",
     "UtilitiesService",
-    "LegacyFilesService"
+    "LegacyFilesService",
 ]

--- a/contxt/services/contxt.py
+++ b/contxt/services/contxt.py
@@ -92,10 +92,18 @@ class ContxtService(ConfiguredApi):
         resp = self.get(f"stacks/{project_id}")
         return Project.from_api(resp)
 
-    def get_services(self, project_id: int) -> List[Service]:
-        resp = self.get(f"stacks/{project_id}")
-        return [Service.from_api(rec) for rec in resp['Services']]
+    def get_services(self, project_id: int = None) -> List[Service]:
+        if project_id:
+            resp = self.get(f"stacks/{project_id}")
+            return [Service.from_api(rec) for rec in resp['Services']]
+        else:
+            resp = self.get(f"services")
+            return sorted([Service.from_api(rec) for rec in resp])
 
     def get_edge_nodes(self, organization_id: str, project_id: int) -> List[Service]:
         resp = self.get(f"organizations/{organization_id}/stacks/{project_id}/edgenodes")
         return [EdgeNode.from_api(rec) for rec in resp]
+
+    def get_service(self, service_id: int):
+        resp = self.get(f"services/{service_id}")
+        return Service.from_api(resp)

--- a/contxt/services/contxt.py
+++ b/contxt/services/contxt.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from ..auth import Auth
-from ..models.contxt import Config, ConfigValue, Organization, OrganizationUser, User
+from ..models.contxt import Config, ConfigValue, Organization, OrganizationUser, User, Project, Service, EdgeNode
 from .api import ApiEnvironment, ConfiguredApi
 
 
@@ -83,3 +83,19 @@ class ContxtService(ConfiguredApi):
     def create_worker_run_metric(self, run_id: str, key: str, value: Any) -> Dict:
         data = {"key": key, "value": value}
         return self.post(f"runs/{run_id}/metrics", data=data)
+
+    def get_projects(self) -> List[Project]:
+        resp = self.get("stacks")
+        return [Project.from_api(rec) for rec in resp]
+
+    def get_project(self, project_id) -> Project:
+        resp = self.get(f"stacks/{project_id}")
+        return Project.from_api(resp)
+
+    def get_services(self, project_id: int) -> List[Service]:
+        resp = self.get(f"stacks/{project_id}")
+        return [Service.from_api(rec) for rec in resp['Services']]
+
+    def get_edge_nodes(self, organization_id: str, project_id: int) -> List[Service]:
+        resp = self.get(f"organizations/{organization_id}/stacks/{project_id}/edgenodes")
+        return [EdgeNode.from_api(rec) for rec in resp]

--- a/contxt/services/contxt.py
+++ b/contxt/services/contxt.py
@@ -2,7 +2,16 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from ..auth import Auth
-from ..models.contxt import Config, ConfigValue, Organization, OrganizationUser, User, Project, Service, EdgeNode
+from ..models.contxt import (
+    Config,
+    ConfigValue,
+    EdgeNode,
+    Organization,
+    OrganizationUser,
+    Project,
+    Service,
+    User,
+)
 from .api import ApiEnvironment, ConfiguredApi
 
 
@@ -95,9 +104,9 @@ class ContxtService(ConfiguredApi):
     def get_services(self, project_id: int = None) -> List[Service]:
         if project_id:
             resp = self.get(f"stacks/{project_id}")
-            return [Service.from_api(rec) for rec in resp['Services']]
+            return [Service.from_api(rec) for rec in resp["Services"]]
         else:
-            resp = self.get(f"services")
+            resp = self.get("services")
             return sorted([Service.from_api(rec) for rec in resp])
 
     def get_edge_nodes(self, organization_id: str, project_id: int) -> List[Service]:

--- a/contxt/services/ems.py
+++ b/contxt/services/ems.py
@@ -75,9 +75,9 @@ class EmsService(ConfiguredApi):
         pro_forma: bool = False,
     ) -> UtilityUsage:
         """Get monthly utility usage for facility `facility_id` and resource
-                `resource_type` (for now, this must be "electric" but will be expanded).
-                Note `start_date` defaults to 10 years ago (the API's maximum limit) and
-                `end_date` defaults to today."""
+        `resource_type` (for now, this must be "electric" but will be expanded).
+        Note `start_date` defaults to 10 years ago (the API's maximum limit) and
+        `end_date` defaults to today."""
         resp = self.get(
             f"facilities/{facility_id}/usage/{interval}",
             params={

--- a/contxt/services/ems.py
+++ b/contxt/services/ems.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta, datetime
+from datetime import date, datetime, timedelta
 from typing import Iterable, List, Optional
 
 from ..auth import Auth
@@ -65,7 +65,8 @@ class EmsService(ConfiguredApi):
         )
         return UtilitySpend.from_api(resp)
 
-    def get_ems_usage(self,
+    def get_ems_usage(
+        self,
         facility_id: int,
         interval: str,
         resource_type: ResourceType = ResourceType.ELECTRIC,
@@ -81,7 +82,9 @@ class EmsService(ConfiguredApi):
             f"facilities/{facility_id}/usage/{interval}",
             params={
                 "type": resource_type.value,
-                "time_start": int(datetime(start_date.year, start_date.month, start_date.day).timestamp()),
+                "time_start": int(
+                    datetime(start_date.year, start_date.month, start_date.day).timestamp()
+                ),
                 "time_end": int(datetime(end_date.year, end_date.month, end_date.day).timestamp()),
                 "pro_forma": pro_forma,
             },
@@ -100,12 +103,14 @@ class EmsService(ConfiguredApi):
         `resource_type` (for now, this must be "electric" but will be expanded).
         Note `start_date` defaults to 10 years ago (the API's maximum limit) and
         `end_date` defaults to today."""
-        return self._get_ems_usage(facility_id=facility_id,
-                                   interval="monthly",
-                                   resource_type=resource_type,
-                                   start_date=start_date,
-                                   end_date=end_date,
-                                   pro_forma=pro_forma)
+        return self.get_ems_usage(
+            facility_id=facility_id,
+            interval="monthly",
+            resource_type=resource_type,
+            start_date=start_date,
+            end_date=end_date,
+            pro_forma=pro_forma,
+        )
 
     def get_daily_utility_usage(
         self,
@@ -119,12 +124,14 @@ class EmsService(ConfiguredApi):
         `resource_type` (for now, this must be "electric" but will be expanded).
         Note `start_date` defaults to 10 years ago (the API's maximum limit) and
         `end_date` defaults to today."""
-        return self._get_ems_usage(facility_id=facility_id,
-                                   interval="daily",
-                                   resource_type=resource_type,
-                                   start_date=start_date,
-                                   end_date=end_date,
-                                   pro_forma=pro_forma)
+        return self.get_ems_usage(
+            facility_id=facility_id,
+            interval="daily",
+            resource_type=resource_type,
+            start_date=start_date,
+            end_date=end_date,
+            pro_forma=pro_forma,
+        )
 
     def get_utility_contracts_for_facility(self, facility_id: int) -> Iterable[UtilityContract]:
         return PagedRecords(

--- a/contxt/services/ems.py
+++ b/contxt/services/ems.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 from typing import Iterable, List, Optional
 
 from ..auth import Auth
@@ -65,6 +65,29 @@ class EmsService(ConfiguredApi):
         )
         return UtilitySpend.from_api(resp)
 
+    def get_ems_usage(self,
+        facility_id: int,
+        interval: str,
+        resource_type: ResourceType = ResourceType.ELECTRIC,
+        start_date: date = date.today() - timedelta(days=3600),
+        end_date: date = date.today(),
+        pro_forma: bool = False,
+    ) -> UtilityUsage:
+        """Get monthly utility usage for facility `facility_id` and resource
+                `resource_type` (for now, this must be "electric" but will be expanded).
+                Note `start_date` defaults to 10 years ago (the API's maximum limit) and
+                `end_date` defaults to today."""
+        resp = self.get(
+            f"facilities/{facility_id}/usage/{interval}",
+            params={
+                "type": resource_type.value,
+                "time_start": int(datetime(start_date.year, start_date.month, start_date.day).timestamp()),
+                "time_end": int(datetime(end_date.year, end_date.month, end_date.day).timestamp()),
+                "pro_forma": pro_forma,
+            },
+        )
+        return UtilityUsage.from_api(resp)
+
     def get_monthly_utility_usage(
         self,
         facility_id: int,
@@ -77,16 +100,31 @@ class EmsService(ConfiguredApi):
         `resource_type` (for now, this must be "electric" but will be expanded).
         Note `start_date` defaults to 10 years ago (the API's maximum limit) and
         `end_date` defaults to today."""
-        resp = self.get(
-            f"facilities/{facility_id}/utility/usage/monthly",
-            params={
-                "type": resource_type.value,
-                "date_start": start_date.strftime("%Y-%m"),
-                "date_end": end_date.strftime("%Y-%m"),
-                "pro_forma": pro_forma,
-            },
-        )
-        return UtilityUsage.from_api(resp)
+        return self._get_ems_usage(facility_id=facility_id,
+                                   interval="monthly",
+                                   resource_type=resource_type,
+                                   start_date=start_date,
+                                   end_date=end_date,
+                                   pro_forma=pro_forma)
+
+    def get_daily_utility_usage(
+        self,
+        facility_id: int,
+        resource_type: ResourceType = ResourceType.ELECTRIC,
+        start_date: date = date.today() - timedelta(days=3600),
+        end_date: date = date.today(),
+        pro_forma: bool = False,
+    ) -> UtilityUsage:
+        """Get monthly utility usage for facility `facility_id` and resource
+        `resource_type` (for now, this must be "electric" but will be expanded).
+        Note `start_date` defaults to 10 years ago (the API's maximum limit) and
+        `end_date` defaults to today."""
+        return self._get_ems_usage(facility_id=facility_id,
+                                   interval="daily",
+                                   resource_type=resource_type,
+                                   start_date=start_date,
+                                   end_date=end_date,
+                                   pro_forma=pro_forma)
 
     def get_utility_contracts_for_facility(self, facility_id: int) -> Iterable[UtilityContract]:
         return PagedRecords(

--- a/contxt/services/files.py
+++ b/contxt/services/files.py
@@ -1,10 +1,7 @@
-from typing import List, Optional
-import json
-
 from contxt.auth import Auth
+from contxt.models.files import FileRead
 from contxt.services.api import ApiEnvironment, ConfiguredApi
 from contxt.utils import make_logger
-from contxt.models.files import FileRead
 
 logger = make_logger(__name__)
 
@@ -20,12 +17,7 @@ class LegacyFilesService(ConfiguredApi):
         ),
     )
 
-    def __init__(
-        self,
-        auth: Auth,
-        env: str = "production",
-        **kwargs,
-    ) -> None:
+    def __init__(self, auth: Auth, env: str = "production", **kwargs,) -> None:
         super().__init__(env=env, auth=auth, **kwargs)
 
     def request_read_file(self, file_id) -> FileRead:

--- a/contxt/services/files.py
+++ b/contxt/services/files.py
@@ -1,0 +1,33 @@
+from typing import List, Optional
+import json
+
+from contxt.auth import Auth
+from contxt.services.api import ApiEnvironment, ConfiguredApi
+from contxt.utils import make_logger
+from contxt.models.files import FileRead
+
+logger = make_logger(__name__)
+
+
+class LegacyFilesService(ConfiguredApi):
+    """Legacy Files API client"""
+
+    _envs = (
+        ApiEnvironment(
+            name="production",
+            base_url="https://sis.api.ndustrial.io/v1",
+            client_id="rPDKeB6b9n7tBo5il9eY3XrJ8yKeF3ho",
+        ),
+    )
+
+    def __init__(
+        self,
+        auth: Auth,
+        env: str = "production",
+        **kwargs,
+    ) -> None:
+        super().__init__(env=env, auth=auth, **kwargs)
+
+    def request_read_file(self, file_id) -> FileRead:
+        resp = self.get(f"files/{file_id}/read")
+        return FileRead.from_api(resp)

--- a/contxt/services/utilities.py
+++ b/contxt/services/utilities.py
@@ -1,10 +1,9 @@
-from typing import List, Optional
-import json
+from typing import List
 
 from contxt.auth import Auth
+from contxt.models.ems import UtilityAccount, UtilityMeter, UtilityStatement
 from contxt.services.api import ApiEnvironment, ConfiguredApi
 from contxt.utils import make_logger
-from contxt.models.ems import UtilityStatement, UtilityAccount, UtilityMeter
 
 logger = make_logger(__name__)
 
@@ -20,12 +19,7 @@ class UtilitiesService(ConfiguredApi):
         ),
     )
 
-    def __init__(
-        self,
-        auth: Auth,
-        env: str = "production",
-        **kwargs,
-    ) -> None:
+    def __init__(self, auth: Auth, env: str = "production", **kwargs,) -> None:
         super().__init__(env=env, auth=auth, **kwargs)
 
     def get_statements(self, facility_id) -> List[UtilityStatement]:
@@ -42,6 +36,3 @@ class UtilitiesService(ConfiguredApi):
 
     def get_statement_data(self, statement_id):
         return self.get(f"utilities/statements/{statement_id}/tree")
-
-
-

--- a/contxt/services/utilities.py
+++ b/contxt/services/utilities.py
@@ -5,7 +5,6 @@ from contxt.auth import Auth
 from contxt.services.api import ApiEnvironment, ConfiguredApi
 from contxt.utils import make_logger
 from contxt.models.ems import UtilityStatement, UtilityAccount, UtilityMeter
-from contxt.models.resource import Resource
 
 logger = make_logger(__name__)
 
@@ -28,14 +27,6 @@ class UtilitiesService(ConfiguredApi):
         **kwargs,
     ) -> None:
         super().__init__(env=env, auth=auth, **kwargs)
-
-    def get_accounts(self) -> List[Resource]:
-        resp = self.get(f"utilities/accounts")
-        return [rec for rec in resp]
-
-    def get_meters(self) -> List[Resource]:
-        resp = self.get("utilities/meters")
-        return [rec for rec in resp]
 
     def get_statements(self, facility_id) -> List[UtilityStatement]:
         resp = self.get(f"facilities/{facility_id}/utilities/statements")

--- a/contxt/services/utilities.py
+++ b/contxt/services/utilities.py
@@ -1,0 +1,56 @@
+from typing import List, Optional
+import json
+
+from contxt.auth import Auth
+from contxt.services.api import ApiEnvironment, ConfiguredApi
+from contxt.utils import make_logger
+from contxt.models.ems import UtilityStatement, UtilityAccount, UtilityMeter
+from contxt.models.resource import Resource
+
+logger = make_logger(__name__)
+
+
+class UtilitiesService(ConfiguredApi):
+    """Utilities API client"""
+
+    _envs = (
+        ApiEnvironment(
+            name="production",
+            base_url="https://sis.api.ndustrial.io/v1",
+            client_id="rPDKeB6b9n7tBo5il9eY3XrJ8yKeF3ho",
+        ),
+    )
+
+    def __init__(
+        self,
+        auth: Auth,
+        env: str = "production",
+        **kwargs,
+    ) -> None:
+        super().__init__(env=env, auth=auth, **kwargs)
+
+    def get_accounts(self) -> List[Resource]:
+        resp = self.get(f"utilities/accounts")
+        return [rec for rec in resp]
+
+    def get_meters(self) -> List[Resource]:
+        resp = self.get("utilities/meters")
+        return [rec for rec in resp]
+
+    def get_statements(self, facility_id) -> List[UtilityStatement]:
+        resp = self.get(f"facilities/{facility_id}/utilities/statements")
+        return [UtilityStatement.from_api(rec) for rec in resp]
+
+    def get_meters(self, facility_id):
+        resp = self.get(f"facilities/{facility_id}/utilities/meters")
+        return [UtilityMeter.from_api(rec) for rec in resp]
+
+    def get_accounts(self, facility_id):
+        resp = self.get(f"facilities/{facility_id}/utilities/accounts")
+        return [UtilityAccount.from_api(rec) for rec in resp]
+
+    def get_statement_data(self, statement_id):
+        return self.get(f"utilities/statements/{statement_id}/tree")
+
+
+

--- a/contxt/utils/serializer.py
+++ b/contxt/utils/serializer.py
@@ -40,7 +40,6 @@ class Serializer:
         # TODO: this may not return a dict but instead a list, or a native type
         # (for example, if passed an int, it will return it). this is likely
         # an unexpected behavior for callers
-
         # NOTE: alternative (but slower) implementations:
         # 1. d = json.dumps(d, default=lambda o: getattr(o, "__dict__", str(o)))
         # 2. d = jsonpickle.encode(d, unpicklable=False))
@@ -109,7 +108,6 @@ class Serializer:
                 return dump(d, f, **kwargs)
         return dumps(d, **kwargs)
 
-
     @staticmethod
     def to_pretty_cli(obj: Any, **kwargs):
 
@@ -124,17 +122,17 @@ class Serializer:
         printed = "\n====" + type(obj).__name__ + "====\n"
         for key in nested_sections:
             del d[key]
-        printed += Serializer.to_table(d) + '\n'
+        printed += Serializer.to_table(d) + "\n"
 
         for key, value in nested_sections.items():
-            printed += '\n' + key.capitalize() + '\n'
-            printed += (Serializer.to_table(value))
-            printed += '\n'
+            printed += "\n" + key.capitalize() + "\n"
+            printed += Serializer.to_table(value)
+            printed += "\n"
 
         return printed
 
     @staticmethod
-    def to_table(obj: Any, path: Optional[Path] = None, exclude_keys = None, sort_by = None, **kwargs):
+    def to_table(obj: Any, path: Optional[Path] = None, exclude_keys=None, sort_by=None, **kwargs):
         """Serializes `obj` to a table.
 
         :param obj: object to serialize
@@ -149,8 +147,6 @@ class Serializer:
             exclude_keys = []
 
         d = Serializer.to_dict(obj)
-
-
 
         # TODO: The above may be a list, so handle it here
         if not isinstance(d, (list, tuple)):

--- a/contxt/utils/serializer.py
+++ b/contxt/utils/serializer.py
@@ -109,6 +109,30 @@ class Serializer:
                 return dump(d, f, **kwargs)
         return dumps(d, **kwargs)
 
+
+    @staticmethod
+    def to_pretty_cli(obj: Any, **kwargs):
+
+        d = Serializer.to_dict(obj)
+
+        nested_sections = {}
+        for key, value in d.items():
+            if isinstance(value, (list, tuple)):
+                nested_sections[key] = value
+
+        # delete the values out of the main section that we're plucking out to print below
+        printed = "\n====" + type(obj).__name__ + "====\n"
+        for key in nested_sections:
+            del d[key]
+        printed += Serializer.to_table(d) + '\n'
+
+        for key, value in nested_sections.items():
+            printed += '\n' + key.capitalize() + '\n'
+            printed += (Serializer.to_table(value))
+            printed += '\n'
+
+        return printed
+
     @staticmethod
     def to_table(obj: Any, path: Optional[Path] = None, **kwargs):
         """Serializes `obj` to a table.

--- a/contxt/utils/serializer.py
+++ b/contxt/utils/serializer.py
@@ -134,7 +134,7 @@ class Serializer:
         return printed
 
     @staticmethod
-    def to_table(obj: Any, path: Optional[Path] = None, **kwargs):
+    def to_table(obj: Any, path: Optional[Path] = None, exclude_keys = None, sort_by = None, **kwargs):
         """Serializes `obj` to a table.
 
         :param obj: object to serialize
@@ -145,13 +145,23 @@ class Serializer:
         :rtype: tabulate
         """
 
+        if exclude_keys is None:
+            exclude_keys = []
+
         d = Serializer.to_dict(obj)
+
+
 
         # TODO: The above may be a list, so handle it here
         if not isinstance(d, (list, tuple)):
             d = [d]
 
-        table = tabulate(d, headers="keys", **kwargs)
+        filtered = [{k: v for k, v in item.items() if k not in exclude_keys} for item in d]
+
+        if sort_by is not None:
+            filtered = sorted(filtered, key=lambda item: item[sort_by])
+
+        table = tabulate(filtered, headers="keys", **kwargs)
         if path:
             with path.open("w") as f:
                 return f.write(table)

--- a/contxt/utils/serializer.py
+++ b/contxt/utils/serializer.py
@@ -117,7 +117,7 @@ class Serializer:
 
         nested_sections = {}
         for key, value in d.items():
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, (list, tuple, dict)):
                 nested_sections[key] = value
 
         # delete the values out of the main section that we're plucking out to print below

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,14 +77,15 @@ subcommands:
 ```console
 $ contxt ems -h 
 usage: contxt ems [-h]
-                  {util-spend,util-usage,util-spend-metrics,util-usage-metrics}
+                  {bills,util-spend,util-usage,util-spend-metrics,util-usage-metrics}
                   ...
 
 optional arguments:
   -h, --help            show this help message and exit
 
 subcommands:
-  {util-spend,util-usage,util-spend-metrics,util-usage-metrics}
+  {bills,util-spend,util-usage,util-spend-metrics,util-usage-metrics}
+    bills               Utility bills
     util-spend          Utility spend
     util-usage          Utility usage
     util-spend-metrics  Utility spend metrics


### PR DESCRIPTION
## Why?
* Working towards a CLI for contxt -- first starting with listing projects / stacks that are being used and their associated services (listing only)
* Support for data exports for EMS-related requests so we have a method for our users and internal support to retrieve data in a common place

## What changed?
- [x] Addition of CLI command for getting a list of projects `contxt projects`
- [x] Addition of CLI command for getting information about a single project and its services `contxt projects get 1`
- [x] Addition of CLI command for getting information about a single service `contxt services get 144`
- [x] Addition of CLI command for getting a list of services within a project `contxt projects get-services 1`
- [x] Addition of CLI command get getting a list of edge nodes within a project `contxt projects get-edge-nodes 1`
- [x] Addition of a serializer utility to take a complex return object with embedded models and "pretty print" it to the command line
- [x] Addition of Utility data services and models
- [x] Addition of a `--download` option to export utility bill data (`contxt ems bills <facility_ids> --download`)
- [x] Addition of a `--download` option to export facility main meter data (`contxt ems util-usage -f 75 daily electric 2020-01-01 2020-02-01`)
- [ ] Documentation on how to use these utilities