### PR TITLE
Exposing deletion endpoint through the CLI

### DIFF
--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import click
+
 from contxt.cli.clients import Clients
 from contxt.cli.utils import LAST_WEEK, NOW, ClickPath, fields_option, print_table, sort_option
 from contxt.models.iot import Feed, Field, FieldGrouping, Window
@@ -71,7 +72,7 @@ def delete_data_point(
 ) -> None:
     """Delete data point"""
     clients.iot.delete_time_series_point(output_id, field, interval, time)
-    print(f"Data point deleted")
+    print("Data point deleted")
 
 
 @iot.command()

--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -49,7 +49,7 @@ def groupings(clients: Clients, facility_id: int, fields: List[str], sort: str) 
 
 
 @iot.command()
-@click.option("--output_id", required=True, type=int, help="Output ID to delete from")
+@click.option("--output-id", required=True, type=int, help="Output ID to delete from")
 @click.option(
     "--field", required=True, type=str, help="The field to delete from. Ex: power.demand, power.usage",
 )

--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -51,7 +51,7 @@ def groupings(clients: Clients, facility_id: int, fields: List[str], sort: str) 
 @iot.command()
 @click.option("--output-id", required=True, type=int, help="Output ID to delete from")
 @click.option(
-    "--field", required=True, type=str, help="The field to delete from. Ex: power.demand, power.usage",
+    "--field-human-name", required=True, help="The field to delete from. Ex: power.demand, power.usage",
 )
 @click.option(
     "--interval",

--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import click
-
 from contxt.cli.clients import Clients
 from contxt.cli.utils import LAST_WEEK, NOW, ClickPath, fields_option, print_table, sort_option
 from contxt.models.iot import Feed, Field, FieldGrouping, Window
@@ -46,6 +45,33 @@ def groupings(clients: Clients, facility_id: int, fields: List[str], sort: str) 
     """Get field groupings"""
     items = clients.iot.get_field_groupings_for_facility(facility_id)
     print_table(items=items, keys=fields, sort_by=sort)
+
+
+@iot.command()
+@click.option("--output_id", required=True, type=int, help="Output ID to delete from")
+@click.option(
+    "--field", required=True, type=str, help="The field to delete from. Ex: power.demand, power.usage",
+)
+@click.option(
+    "--interval",
+    required=True,
+    type=click.Choice([str(v.value) for v in Window]),
+    callback=lambda ctx, param, value: Window(int(value)) if value is not None else None,
+    help="Time interval",
+)
+@click.option(
+    "--time",
+    required=True,
+    type=click.DateTime(),
+    help="The timestamp of the datapoint. Ex: 2020-07-21 05:31:00",
+)
+@click.pass_obj
+def delete_data_point(
+    clients: Clients, output_id: int, field: str, interval: Window, time: datetime
+) -> None:
+    """Delete data point"""
+    clients.iot.delete_time_series_point(output_id, field, interval, time)
+    print(f"Data point deleted")
 
 
 @iot.command()

--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import click
+
 from contxt.cli.clients import Clients
 from contxt.cli.utils import LAST_WEEK, NOW, ClickPath, fields_option, print_table, sort_option
 from contxt.models.iot import Feed, Field, FieldGrouping, Window

--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import click
-
 from contxt.cli.clients import Clients
 from contxt.cli.utils import LAST_WEEK, NOW, ClickPath, fields_option, print_table, sort_option
 from contxt.models.iot import Feed, Field, FieldGrouping, Window
@@ -64,7 +63,7 @@ def groupings(clients: Clients, facility_id: int, fields: List[str], sort: str) 
     "--time",
     required=True,
     type=click.DateTime(),
-    help="The timestamp of the datapoint. Ex: 2020-07-21 05:31:00",
+    help="The timestamp of the datapoint. Ex: 2020-07-21T05:31:00Z",
 )
 @click.pass_obj
 def delete_data_point(

--- a/contxt/services/iot.py
+++ b/contxt/services/iot.py
@@ -46,6 +46,14 @@ class IotService(ConfiguredApi):
     def __init__(self, auth: Auth, env: str = "production", **kwargs) -> None:
         super().__init__(env=env, auth=auth, **kwargs)
 
+    def delete_time_series_point(
+        self, output_id: int, field: str, interval: Window, time: datetime
+    ) -> Optional[Dict]:
+        """Delete a point from the time series data by interval and timestamp"""
+        return self.delete(
+            f"outputs/{output_id}/fields/{field}/data/window/{interval.value}/event_time/{time}"
+        )
+
     def get_feed_with_id(self, id: int) -> Feed:
         """Get feed with id `id`"""
         return Feed.from_api(self.get(f"feeds/{id}"))


### PR DESCRIPTION
## Why?
* [JIRA](https://ndustrialio.atlassian.net/browse/CONTXT-1483): Background for changes

## What changed?
- Exposed endpoint through the CLI

Sample command:
`contxt iot delete-data-point --output-id 1939 --field-human-name power.demand --interval 900 --time 2020-08-04T03:00:00Z`
