### PR TITLE
fix: ems export command

### DIFF
--- a/contxt/cli/commands/ems.py
+++ b/contxt/cli/commands/ems.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from csv import DictWriter
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
@@ -234,9 +233,4 @@ def _download_bills(sis_api, facility_id, bills, output):
         data.append(row)
 
     # Dump
-    columns = data[0].keys() if data else []
-    output.mkdir(parents=True, exist_ok=True)
-    with (output / "summary.csv").open("w") as f:
-        writer = DictWriter(f, fieldnames=columns)
-        writer.writeheader()
-        writer.writerows(data)
+    Serializer.to_csv(data, path=output / "summary.csv")

--- a/contxt/utils/serializer.py
+++ b/contxt/utils/serializer.py
@@ -16,7 +16,7 @@ class Serializer:
         if isinstance(obj, dict):
             return obj.keys()
         elif isinstance(obj, (list, tuple)) and obj:
-            return list(set().union(*(Serializer._keys(i) for i in obj)))
+            return list(sorted(set().union(*(Serializer._keys(i) for i in obj))))
         else:
             return []
 


### PR DESCRIPTION
## Why?
* Dumping to csv assumed that the first row contained all columns present in every other row. Don't make that assumption
