### PR TITLE
feat(cli): add token command

### DIFF
--- a/contxt/cli/commands/auth.py
+++ b/contxt/cli/commands/auth.py
@@ -10,13 +10,22 @@ def auth() -> None:
 
 @auth.command()
 @click.pass_obj
-def login(client: Clients):
+def login(client: Clients) -> None:
     """Login to Contxt."""
     client.auth.login()
 
 
 @auth.command()
 @click.pass_obj
-def logout(client: Clients):
+def logout(client: Clients) -> None:
     """Logout of Contxt."""
     client.auth.logout()
+
+
+@auth.command()
+@click.argument("audience")
+@click.pass_obj
+def token(client: Clients, audience: str) -> None:
+    """Fetch token for an API."""
+    token = client.auth.get_token_provider(audience).access_token
+    print(token)


### PR DESCRIPTION
This adds a convenience command to get an access token for a certain audience (i.e. one of our API's). For example:

```sh
contxt auth token <audience>
```

This is useful when you want to make API requests yourself, outside of the sdk.