### PR TITLE
Make id optional. No longer required

### DIFF
--- a/contxt/models/ems.py
+++ b/contxt/models/ems.py
@@ -80,7 +80,7 @@ class Metric(ApiObject):
 @dataclass
 class MetricValue(ApiObject):
     _api_fields: ClassVar = (
-        ApiField("id"),
+        ApiField("id", optional=True),
         ApiField("effective_start_date", data_type=Parsers.datetime, creatable=True, updatable=True),
         ApiField("effective_end_date", data_type=Parsers.datetime, creatable=True, updatable=True),
         ApiField("value", data_type=float, creatable=True, updatable=True),


### PR DESCRIPTION
## Why?
* The `id` field is not longer being returned and is not necessary to make the call/response work.

## What changed?
- [x] Made `id` optional
