### PR TITLE
Feature: Add bus channel creation. Add raw post option

### DIFF
--- a/contxt/models/bus.py
+++ b/contxt/models/bus.py
@@ -80,16 +80,16 @@ class SubscriberStats(ApiObject):
 @dataclass
 class Channel(ApiObject):
     _api_fields: ClassVar = (
-        ApiField("id"),
-        ApiField("name"),
-        ApiField("organization_id"),
-        ApiField("service_id"),
+        ApiField("id", data_type=str, optional=True),
+        ApiField("name", data_type=str),
+        ApiField("organization_id", data_type=str),
+        ApiField("service_id", data_type=str),
     )
 
-    id: str
     name: str
-    organization_id: str
     service_id: str
+    organization_id: str
+    id: Optional[str] = None
 
     def __str__(self) -> str:
         return pretty_print(self)

--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -115,7 +115,9 @@ class Api:
         response = self.session.get(url=self._url(uri), params=params, **kwargs)
         return self._process_response(response)
 
-    def raw_post(self, uri: str, data: Optional[Dict] = None, json: Optional[Dict] = None, **kwargs) -> requests.Response:
+    def raw_post(
+        self, uri: str, data: Optional[Dict] = None, json: Optional[Dict] = None, **kwargs
+    ) -> requests.Response:
         """Sends a POST request without processing response"""
         return self.session.post(url=self._url(uri), data=data, json=json, **kwargs)
 

--- a/contxt/services/api.py
+++ b/contxt/services/api.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, FrozenSet, Optional, Tuple
 
+import requests
 from requests import PreparedRequest, Response, Session
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
@@ -113,6 +114,10 @@ class Api:
         """Sends a GET request"""
         response = self.session.get(url=self._url(uri), params=params, **kwargs)
         return self._process_response(response)
+
+    def raw_post(self, uri: str, data: Optional[Dict] = None, json: Optional[Dict] = None, **kwargs) -> requests.Response:
+        """Sends a POST request without processing response"""
+        return self.session.post(url=self._url(uri), data=data, json=json, **kwargs)
 
     def post(self, uri: str, data: Optional[Dict] = None, json: Optional[Dict] = None, **kwargs) -> Dict:
         """Sends a POST request"""

--- a/contxt/services/bus.py
+++ b/contxt/services/bus.py
@@ -21,6 +21,13 @@ class MessageBusService(ConfiguredApi):
         resp = self.get(f"{self._channels_url(service_id)}/{channel_id}")
         return Channel.from_api(resp)
 
+    def create_channel_for_service(self, channel: Channel) -> Channel:
+        data = {
+            'name': channel.name
+        }
+        resp = self.post(f"{self._channels_url(channel.service_id)}", json=data)
+        return Channel.from_api(resp)
+
     def get_channel_with_name_for_service(self, channel_name: str, service_id: str) -> Optional[Channel]:
         for channel in self.get_channels_for_service(service_id):
             if channel.name.lower() == channel_name.lower():

--- a/contxt/services/bus.py
+++ b/contxt/services/bus.py
@@ -22,9 +22,7 @@ class MessageBusService(ConfiguredApi):
         return Channel.from_api(resp)
 
     def create_channel_for_service(self, channel: Channel) -> Channel:
-        data = {
-            'name': channel.name
-        }
+        data = {"name": channel.name}
         resp = self.post(f"{self._channels_url(channel.service_id)}", json=data)
         return Channel.from_api(resp)
 


### PR DESCRIPTION
## Why?
* Adding the ability in another CLI to create a message bus channel
* One of the endpoints in another CLI is calling an endpoint that does not return JSON, but instead an `application/jwt`

## What changed?
- [x] Added a service endpoint for creating a message bus channel
- [x] Updated channel models for creation needs 
- [x] Added a method to return a raw post request (not everything returns JSON) 