### PR TITLE
CONTXT-2845 map project dependencies

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,10 @@
+ndustrial:
+  project: sdk
+  name: contxt-sdk-python
+  type: SDK,CLI
+
+  organization: ndustrial
+  owner: csi
+  managed_by: n/a
+
+  depends: []


### PR DESCRIPTION
## Why?
* [CONTXT-2845](https://ndustrialio.atlassian.net/browse/CONTXT-2845): meta.yaml

## What changed?
- [x] Added meta.yaml file to assist dependency graphing
