### PR TITLE
CONTXT-2921 correct staging endpoints

### DIFF
--- a/contxt/services/contxt.py
+++ b/contxt/services/contxt.py
@@ -26,7 +26,7 @@ class ContxtService(ConfiguredApi):
         ),
         ApiEnvironment(
             name="staging",
-            base_url="https://contxt-api.staging.ndustrial.io/v1",
+            base_url="https://contxt.api.staging.ndustrial.io/v1",
             client_id="qGzdTXcmB57zlTp86rYsivG9qEss1lbF",
         ),
     )

--- a/contxt/services/contxt_deployments.py
+++ b/contxt/services/contxt_deployments.py
@@ -18,7 +18,7 @@ class ContxtDeploymentService(ConfiguredApi):
         ),
         ApiEnvironment(
             name="staging",
-            base_url="https://contxt-api.staging.ndustrial.io/deploy/v1",
+            base_url="https://contxt.api.staging.ndustrial.io/deploy/v1",
             client_id="qGzdTXcmB57zlTp86rYsivG9qEss1lbF",
         ),
     )


### PR DESCRIPTION
## Why?
* [CONTXT-2921](https://ndustrialio.atlassian.net/browse/CONTXT-2921): Background for changes

## What changed?
- [x] Corrected staging contxt auth and contxt api endpoint URIs
