### PR TITLE
corrected typos in CLI help

### DIFF
--- a/contxt/cli/commands/clusters.py
+++ b/contxt/cli/commands/clusters.py
@@ -33,7 +33,7 @@ def get(clients: Clients, fields: List[str], sort: str, cluster_slug: Optional[s
 @click.argument("slug")
 @click.pass_obj
 def login(clients: Clients, slug: str) -> None:
-    """Get clusters"""
+    """Get cluster config"""
     try:
         clusters = clients.contxt_deployments.get_clusters(clients.org_id)
         cluster_host = next((cluster.host for cluster in clusters if cluster.slug == slug), None)

--- a/contxt/cli/commands/services.py
+++ b/contxt/cli/commands/services.py
@@ -55,5 +55,5 @@ def create(clients: Clients, project_id: str, slug: str, type: str, deployment_s
 @click.argument("id")
 @click.pass_obj
 def delete(clients: Clients, id: str) -> None:
-    """Create service"""
+    """Delete service"""
     clients.contxt_deployments.delete(f"{clients.org_id}/services/{id}")


### PR DESCRIPTION
## Why?
* Corrected a couple typos in the CLI help text to avoid confusion
