### PR TITLE
Re-enable release builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,7 @@ jobs:
   release:
     needs: test
     runs-on: ubuntu-latest
-    if: "false"
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
## Why?
* Need a release 3.0.0 in order to get deprecation of assets_api into SDK for customers to use.

## What changed?
- Enable the release workflow.
