### PR TITLE
Fix create field groupings

### DIFF
--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -11,10 +11,10 @@ from slugify import slugify
 
 from contxt.cli.clients import Clients
 from contxt.cli.utils import LAST_WEEK, NOW, ClickPath, fields_option, print_table, sort_option
-from contxt.models.iot import Feed, Field, FieldGrouping, FieldValueType, Window
+from contxt.models.iot import Feed, Field, FieldCategory, FieldGrouping, FieldValueType, Window
 from contxt.utils.serializer import Serializer
 
-NEW_FIELD_ATTRS = ["field_descriptor", "label", "value_type", "units", "grouping"]
+NEW_FIELD_ATTRS = ["field_descriptor", "label", "value_type", "units", "grouping", "category"]
 
 
 @click.group()
@@ -30,6 +30,11 @@ def fields() -> None:
 @iot.group()
 def groupings() -> None:
     """IoT Field Groupings"""
+
+
+@iot.group()
+def categories() -> None:
+    """IoT Grouping Categories"""
 
 
 @iot.group()
@@ -76,6 +81,17 @@ def get(clients: Clients, feed_key: str, fields: List[str], sort: str) -> None:
 def groupings_get(clients: Clients, facility_id: int, fields: List[str], sort: str) -> None:
     """Get field groupings"""
     items = clients.iot.get_field_groupings_for_facility(facility_id)
+    print_table(items=items, keys=fields, sort_by=sort)
+
+
+@categories.command("get")
+@click.argument("facility_id", type=int)
+@fields_option(default="id, name, description, parent_category_id", obj=FieldCategory)
+@sort_option(default="name")
+@click.pass_obj
+def categories_get(clients: Clients, facility_id: int, fields: List[str], sort: str) -> None:
+    """Get categories for facility"""
+    items = clients.iot.get_categories_for_facility(facility_id)
     print_table(items=items, keys=fields, sort_by=sort)
 
 
@@ -168,6 +184,7 @@ def create(clients: Clients, feed_key: str, input: IO[str]) -> None:
                     is_hidden=False,
                 ),
                 r["grouping"],
+                r["category"],
             ]
             for r in DictReader(input)
         ]
@@ -189,7 +206,7 @@ def create(clients: Clients, feed_key: str, input: IO[str]) -> None:
     # Add fields to grouping
     groupings = {g.slug: g for g in clients.iot.get_field_groupings_for_facility(feed.facility_id)}
     with click.progressbar(fields, label="Adding fields to groupings") as fields_:
-        for field, grouping_label in fields_:
+        for field, grouping_label, category in fields_:
             grouping_slug = slugify(cast(str, grouping_label))
             field = cast(Field, field)
             if grouping_slug not in groupings:
@@ -207,6 +224,18 @@ def create(clients: Clients, feed_key: str, input: IO[str]) -> None:
                 grouping = groupings[grouping_slug]
             try:
                 clients.iot.add_field_to_grouping(grouping.id, field.id)
+            except HTTPError as e:
+                logging.debug(e)
+
+    # Add groupings to categories
+    categories = {c.name: c for c in clients.iot.get_categories_for_facility(feed.facility_id)}
+    new_groups = {g: c for f, g, c in fields}
+    with click.progressbar(new_groups, label="Adding groupings to categories") as _groups:
+        for group in _groups:
+            try:
+                clients.iot.add_grouping_to_category(
+                    groupings[slugify(cast(str, group))].id, categories[new_groups[group]].id
+                )
             except HTTPError as e:
                 logging.debug(e)
 
@@ -269,3 +298,12 @@ def fields_delete(clients: Clients, field_id: List[str]):
     """Delete (unprovision) fields"""
     for id in field_id:
         clients.iot.unprovision_field(id)
+
+
+@groupings.command("delete")
+@click.argument("grouping_id", nargs=-1)
+@click.pass_obj
+def groupings_delete(clients: Clients, grouping_id: List[str]):
+    """Delete field groupings (does not delete fields within grouping)"""
+    for id in grouping_id:
+        clients.iot.delete_field_grouping(id)

--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -7,6 +7,7 @@ from typing import IO, Any, Dict, List, Optional, cast
 
 import click
 from requests import HTTPError
+from slugify import slugify
 
 from contxt.cli.clients import Clients
 from contxt.cli.utils import LAST_WEEK, NOW, ClickPath, fields_option, print_table, sort_option
@@ -189,7 +190,8 @@ def create(clients: Clients, feed_key: str, input: IO[str]) -> None:
     groupings = {g.slug: g for g in clients.iot.get_field_groupings_for_facility(feed.facility_id)}
     with click.progressbar(fields, label="Adding fields to groupings") as fields_:
         for field, grouping_label in fields_:
-            grouping_slug = cast(str, grouping_label).lower().replace(" ", "-")
+            # grouping_slug = cast(str, grouping_label).lower().replace(" ", "-")
+            grouping_slug = slugify(cast(str, grouping_label))
             field = cast(Field, field)
             if grouping_slug not in groupings:
                 # New grouping, create it

--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -190,7 +190,6 @@ def create(clients: Clients, feed_key: str, input: IO[str]) -> None:
     groupings = {g.slug: g for g in clients.iot.get_field_groupings_for_facility(feed.facility_id)}
     with click.progressbar(fields, label="Adding fields to groupings") as fields_:
         for field, grouping_label in fields_:
-            # grouping_slug = cast(str, grouping_label).lower().replace(" ", "-")
             grouping_slug = slugify(cast(str, grouping_label))
             field = cast(Field, field)
             if grouping_slug not in groupings:

--- a/contxt/cli/commands/iot.py
+++ b/contxt/cli/commands/iot.py
@@ -232,10 +232,10 @@ def create(clients: Clients, feed_key: str, input: IO[str]) -> None:
     new_groups = {g: c for f, g, c in fields}
     with click.progressbar(new_groups, label="Adding groupings to categories") as _groups:
         for group in _groups:
+            grouping_id = groupings[slugify(cast(str, group))].id
+            category_id = categories[new_groups[group]].id if new_groups[group] != "" else None
             try:
-                clients.iot.add_grouping_to_category(
-                    groupings[slugify(cast(str, group))].id, categories[new_groups[group]].id
-                )
+                clients.iot.add_grouping_to_category(grouping_id, category_id)
             except HTTPError as e:
                 logging.debug(e)
 

--- a/contxt/models/iot.py
+++ b/contxt/models/iot.py
@@ -80,6 +80,18 @@ class FieldCategory(ApiObject):
         ApiField("parent_category_id"),
         ApiField("created_at", data_type=Parsers.datetime),
         ApiField("updated_at", data_type=Parsers.datetime),
+        ApiField(
+            "FieldGroupings",
+            attr_key="field_groupings",
+            data_type=lambda v: FieldGrouping.from_api(v),
+            optional=True,
+        ),
+        ApiField(
+            "Subcategories",
+            attr_key="subcategories",
+            data_type=lambda v: FieldCategory.from_api(v),
+            optional=True,
+        ),
     )
 
     id: str
@@ -89,6 +101,8 @@ class FieldCategory(ApiObject):
     parent_category_id: str
     created_at: datetime
     updated_at: datetime
+    field_groupings: Optional[list["FieldGrouping"]] = None
+    subcategories: Optional[list["FieldCategory"]] = None
 
 
 @dataclass

--- a/contxt/models/iot.py
+++ b/contxt/models/iot.py
@@ -101,8 +101,8 @@ class FieldCategory(ApiObject):
     parent_category_id: str
     created_at: datetime
     updated_at: datetime
-    field_groupings: Optional[list["FieldGrouping"]] = None
-    subcategories: Optional[list["FieldCategory"]] = None
+    field_groupings: Optional[List["FieldGrouping"]] = None
+    subcategories: Optional[List["FieldCategory"]] = None
 
 
 @dataclass

--- a/contxt/services/iot.py
+++ b/contxt/services/iot.py
@@ -13,6 +13,7 @@ from ..models.iot import (
     BatchResponses,
     Feed,
     Field,
+    FieldCategory,
     FieldGrouping,
     FieldTimeSeries,
     UnprovisionedField,
@@ -80,6 +81,9 @@ class IotService(ConfiguredApi):
 
     def unprovision_field(self, field_id: int):
         return self.delete(uri=f"fields/{field_id}")
+
+    def delete_field_grouping(self, grouping_id: str):
+        return self.delete(uri=f"groupings/{grouping_id}")
 
     def delete_time_series_point(
         self, output_id: int, field: str, interval: Window, time: datetime
@@ -264,6 +268,24 @@ class IotService(ConfiguredApi):
     def get_field_grouping(self, id: str) -> FieldGrouping:
         """Get field grouping with id `id`"""
         return FieldGrouping.from_api(self.get(f"groupings/{id}"))
+
+    def get_categories_for_facility(self, facility_id: int) -> List[FieldCategory]:
+        """Get categories for facility with id `facility_id`"""
+        res = [FieldCategory.from_api(rec) for rec in self.get(f"facilities/{facility_id}/categories")]
+        categories = []
+        for cat in res:
+            categories.append(cat)
+            for sub in cat.subcategories:
+                categories.append(sub)
+        return categories
+
+    def add_grouping_to_category(self, grouping_id: str, field_category_id: str):
+        return self.put(
+            f"groupings/{grouping_id}",
+            json={
+                "field_category_id": field_category_id,
+            },
+        )
 
     def get_field_groupings_for_facility(
         self, facility_id: int, page_options: Optional[PageOptions] = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -883,6 +883,24 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-slugify"
+version = "6.1.2"
+description = "A Python slugify application that also handles Unicode"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+files = [
+    {file = "python-slugify-6.1.2.tar.gz", hash = "sha256:272d106cb31ab99b3496ba085e3fea0e9e76dcde967b5e9992500d1f785ce4e1"},
+    {file = "python_slugify-6.1.2-py2.py3-none-any.whl", hash = "sha256:7b2c274c308b62f4269a9ba701aa69a797e9bca41aeee5b3a9e79e36b6656927"},
+]
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -1034,6 +1052,18 @@ files = [
 widechars = ["wcwidth"]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -1139,6 +1169,18 @@ python-versions = "*"
 files = [
     {file = "types-pkg_resources-0.1.3.tar.gz", hash = "sha256:834a9b8d3dbea343562fd99d5d3359a726f6bf9d3733bccd2b4f3096fbab9dae"},
     {file = "types_pkg_resources-0.1.3-py2.py3-none-any.whl", hash = "sha256:0cb9972cee992249f93fff1a491bf2dc3ce674e5a1926e27d4f0866f7d9b6d9c"},
+]
+
+[[package]]
+name = "types-python-slugify"
+version = "8.0.0.1"
+description = "Typing stubs for python-slugify"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-python-slugify-8.0.0.1.tar.gz", hash = "sha256:f2177d2e65ecf2eca742d28fbf236a8d919a72e68272d1d748c3fe965e5ea3ab"},
+    {file = "types_python_slugify-8.0.0.1-py3-none-any.whl", hash = "sha256:1de288ce45c85627ef632c2b5098dedccfc7ebedb241d181ba69402f03704449"},
 ]
 
 [[package]]
@@ -1303,4 +1345,4 @@ crypto = ["cryptography"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "7c6338cfdc4f43855e00a00e7bd757f2365ea2af27873d1e19da2cadec1beb49"
+content-hash = "47f1e3c5f5cab0e27fc94266e3bbb2bd653fcfcf7e79920f09ffe0555d25a96e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pyyaml = ">=5,<7"
 requests = "^2"
 tabulate = "*"
 sgqlc = ">=15,<17"
+python-slugify = "^6.1.2"
 
 [tool.poetry.dev-dependencies]
 black = "^23.1.0"
@@ -35,6 +36,7 @@ types-pkg-resources = "^0.1.3"
 types-pyyaml = "^6.0.12"
 types-requests = "^2.28.11"
 types-tabulate = "^0.9.0.0"
+types-python-slugify = "^8.0.0.1"
 
 [tool.poetry.extras]
 crypto = ["cryptography"]


### PR DESCRIPTION
## Why?
* When generating field groupings from csv, the group name was not properly slugified to match the lookup in the feeds API
* No automation existed for assigning field groupings to categories

## What changed?
- [x] Use `python-slugify` when comparing against existing group names
- [x] Added required column `category` to provisioning import file
- [x] Extended `fields -> create` command to assign category to grouping
- [x] Add `categories -> get` command
- [x] Add `groupings -> delete` command
