### PR TITLE
CONTXT-4194 switch to tenant urls

### DIFF
--- a/contxt/cli/clients.py
+++ b/contxt/cli/clients.py
@@ -54,7 +54,7 @@ class Clients:
 
     @cachedproperty
     def events(self) -> EventsService:
-        return EventsService(auth=self.auth, env=self.env)
+        return EventsService(auth=self.auth, env=self.env, org_id=self.org_id)
 
     @cachedproperty
     def nionic(self) -> NionicService:
@@ -62,4 +62,4 @@ class Clients:
 
     @cachedproperty
     def iot(self) -> IotService:
-        return IotService(auth=self.auth, env=self.env)
+        return IotService(auth=self.auth, env=self.env, org_id=self.org_id)

--- a/contxt/services/ems.py
+++ b/contxt/services/ems.py
@@ -3,6 +3,7 @@ from typing import Iterable, List, Optional
 
 from ..auth import Auth
 from ..models.ems import Facility, MainService, ResourceType, UtilityContract, UtilitySpend, UtilityUsage
+from ..utils.orgs import get_slug_or_org_id
 from .api import ApiEnvironment, ConfiguredApi
 from .pagination import PagedRecords
 
@@ -13,12 +14,12 @@ class EmsService(ConfiguredApi):
     _envs = (
         ApiEnvironment(
             name="production",
-            base_url="https://ems.api.ndustrial.io/v1",
+            base_url="https://{tenant}.api.ndustrial.io/rest/ems/v1",
             client_id="e2IT0Zm9RgGlDBkLa2ruEcN9Iop6dJAS",
         ),
         ApiEnvironment(
             name="staging",
-            base_url="https://ems.staging.api.ndustrial.io/v1",
+            base_url="https://{tenant}.api.staging.ndustrial.io/rest/ems/v1",
             client_id="vMV67yaRFgjBB1JFbT3vXBOlohFdG1I4",
         ),
     )
@@ -26,6 +27,8 @@ class EmsService(ConfiguredApi):
     def __init__(self, auth: Auth, org_id: str, env: str = "production", **kwargs) -> None:
         super().__init__(env=env, auth=auth, **kwargs)
         self.org_id = org_id
+        tenant = get_slug_or_org_id(org_id)
+        self.base_url = self.base_url.format(tenant=tenant)
 
     def get_facility(self, id: int) -> Facility:
         return Facility.from_api(self.get(f"{self.org_id}/facilities/{id}"))

--- a/contxt/services/events.py
+++ b/contxt/services/events.py
@@ -2,6 +2,7 @@ from typing import Iterable, List, Optional
 
 from ..auth import Auth
 from ..models.events import Event, EventDefinition, EventType, TriggeredEvent
+from ..utils.orgs import get_slug_or_org_id
 from .api import ApiEnvironment, ConfiguredApi
 from .pagination import PagedRecords, PageOptions
 
@@ -12,18 +13,20 @@ class EventsService(ConfiguredApi):
     _envs = (
         ApiEnvironment(
             name="production",
-            base_url="https://events.api.ndustrial.io/v1",
+            base_url="https://{tenant}.api.ndustrial.io/rest/events/v1",
             client_id="7jzwfE20O2XZ4aq3cO1wmk63G9GzNc8j",
         ),
         ApiEnvironment(
             name="staging",
-            base_url="https://events.api.staging.ndustrial.io/v1",
+            base_url="https://{tenant}.api.staging.ndustrial.io/rest/events/v1",
             client_id="dn4MaocJFdKtsBy9sFFaTeuJWL1nt5xu",
         ),
     )
 
-    def __init__(self, auth: Auth, env: str = "production", **kwargs) -> None:
+    def __init__(self, auth: Auth, org_id: str, env: str = "production", **kwargs) -> None:
         super().__init__(env=env, auth=auth, **kwargs)
+        tenant = get_slug_or_org_id(org_id)
+        self.base_url = self.base_url.format(tenant=tenant)
 
     def set_human_readable_parameters(self, event_definition: EventDefinition) -> None:
         statement = ""

--- a/contxt/services/iot.py
+++ b/contxt/services/iot.py
@@ -20,6 +20,7 @@ from ..models.iot import (
 )
 from ..utils import is_datetime_aware, make_logger
 from ..utils.object_mapper import ObjectMapper
+from ..utils.orgs import get_slug_or_org_id
 from .api import ApiEnvironment, ConfiguredApi
 from .pagination import DataPoint, PagedRecords, PagedTimeSeries, PageOptions
 
@@ -38,18 +39,20 @@ class IotService(ConfiguredApi):
     _envs = (
         ApiEnvironment(
             name="production",
-            base_url="https://feeds.api.ndustrial.io/v1",
+            base_url="https://{tenant}.api.ndustrial.io/rest/iot/v1",
             client_id="iznTb30Sfp2Jpaf398I5DN6MyPuDCftA",
         ),
         ApiEnvironment(
             name="staging",
-            base_url="https://feeds.api.staging.ndustrial.io/v1",
+            base_url="https://{tenant}.api.staging.ndustrial.io/rest/iot/v1",
             client_id="m35AEcxD8hf65sq04ZU7yFxqpqVkKzES",
         ),
     )
 
-    def __init__(self, auth: Auth, env: str = "production", **kwargs) -> None:
+    def __init__(self, auth: Auth, org_id: str, env: str = "production", **kwargs) -> None:
         super().__init__(env=env, auth=auth, **kwargs)
+        tenant = get_slug_or_org_id(org_id)
+        self.base_url = self.base_url.format(tenant=tenant)
 
     def provision_field_for_feed(self, feed_id: int, field: Field) -> Field:
         resp = self.post(f"feeds/{feed_id}/fields", data=field.post())

--- a/contxt/services/nionic.py
+++ b/contxt/services/nionic.py
@@ -7,6 +7,7 @@ from contxt.models.facilities import Facility, MetricData, MetricLabel, Mutation
 from contxt.services.api import ApiEnvironment, BaseGraphService
 
 from ..auth import Auth
+from ..utils.orgs import get_slug_or_org_id
 
 
 class NionicService(BaseGraphService):
@@ -15,27 +16,20 @@ class NionicService(BaseGraphService):
     _envs = (
         ApiEnvironment(
             name="production",
-            base_url="https://<tenant>.api.ndustrial.io",
+            base_url="https://{tenant}.api.ndustrial.io",
             client_id="vtiZlMRo4apDvThTRiH7kLifQXWUdi9j",
         ),
         ApiEnvironment(
             name="staging",
-            base_url="https://<tenant>.api.staging.ndustrial.io",
+            base_url="https://{tenant}.api.staging.ndustrial.io",
             client_id="vhGxildn8hRRWZj49y18BGtbjTkFHcTG",
         ),
     )
 
-    org_id_slugs = {
-        "18d8b68e-3e59-418e-9f23-47b7cd6bdd6b": "genan",
-        "02efa741-a96f-4124-a463-ae13a704b8fc": "lineage",
-        "2fe29680-fc3d-4888-9e9b-44be1e59c22c": "sfnt",
-        "5209751f-ea46-4b3e-a5dd-b8d03311b791": "ndustrial",
-    }
-
     def __init__(self, auth: Auth, org_id: str, env: str = "production", **kwargs) -> None:
         super().__init__(env=env, auth=auth, **kwargs)
-        slug = self.org_id_slugs.get(org_id) or org_id
-        self.base_url = self.base_url.replace("<tenant>", slug)
+        tenant = get_slug_or_org_id(org_id)
+        self.base_url = self.base_url.format(tenant=tenant)
         self.endpoint = RequestsEndpoint(self.base_url.rstrip("/") + "/graphql", session=self.session)
 
     def get_facilities(self) -> List[Facility]:

--- a/contxt/utils/orgs.py
+++ b/contxt/utils/orgs.py
@@ -1,0 +1,10 @@
+org_id_slugs = {
+    "18d8b68e-3e59-418e-9f23-47b7cd6bdd6b": "genan",
+    "02efa741-a96f-4124-a463-ae13a704b8fc": "lineage",
+    "2fe29680-fc3d-4888-9e9b-44be1e59c22c": "sfnt",
+    "5209751f-ea46-4b3e-a5dd-b8d03311b791": "ndustrial",
+}
+
+
+def get_slug_or_org_id(org_id: str):
+    return org_id_slugs.get(org_id) or org_id


### PR DESCRIPTION
## Why?
* [CONTXT-4194](https://ndustrialio.atlassian.net/browse/CONTXT-4194)

## What changed?
- [x] Updated hostnames with the tenant-based ones.

BREAKING CHANGE: `IotService`, `EventsService`, `NgestService`, and `SpecializedNgestService`
now require `org_id` to be instantiated. This is needed for hitting the tenant-specific APIs.
As such, these services, as well as `EmsService` now point to
https://$TENANT.$SERVICE.api.ndustrial.io.


[CONTXT-4194]: https://ndustrialio.atlassian.net/browse/CONTXT-4194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ