### PR TITLE
fix: add job to ci that wraps all tests for single branch protection …

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,14 @@ jobs:
       - name: Run tests
         run: poetry run poe test
 
-  release:
+  tests-passing:
     needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This job wraps all OS x python-verions tests as a single branch protection check."
+
+  release:
+    needs: tests-passing
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,9 @@ jobs:
           - os: windows-latest
             python: "3.10"
     steps:
+      - run: |
+        echo "This should fail"
+        exit 1
       - uses: actions/checkout@v3
       - run: pipx install poetry
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,6 @@ jobs:
           - os: windows-latest
             python: "3.10"
     steps:
-      - run: |
-          echo "This should fail"
-          exit 1
       - uses: actions/checkout@v3
       - run: pipx install poetry
       - uses: actions/setup-python@v4
@@ -52,10 +49,13 @@ jobs:
         run: poetry run poe test
 
   tests-passing:
-    needs: test
+    if: always()
+    needs: [test]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "This job wraps all OS x python-verions tests as a single branch protection check."
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
 
   release:
     needs: tests-passing

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,9 @@ jobs:
           - os: windows-latest
             python: "3.10"
     steps:
+      - run: |
+          echo "This should fail"
+          exit 1
       - uses: actions/checkout@v3
       - run: pipx install poetry
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,6 @@ jobs:
           - os: windows-latest
             python: "3.10"
     steps:
-      - run: |
-          echo "This should fail"
-          exit 1
       - uses: actions/checkout@v3
       - run: pipx install poetry
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,8 @@ jobs:
             python: "3.10"
     steps:
       - run: |
-        echo "This should fail"
-        exit 1
+          echo "This should fail"
+          exit 1
       - uses: actions/checkout@v3
       - run: pipx install poetry
       - uses: actions/setup-python@v4


### PR DESCRIPTION
## Why?
PR checks were hung since branch protection check named `test` was never running

## What changed?
- wrap all tests from OS/version matrix in a single job that we can protect on
