### PR TITLE
feat: peek messages on a channel subscription

### DIFF
--- a/contxt/services/bus.py
+++ b/contxt/services/bus.py
@@ -49,3 +49,8 @@ class MessageBusService(ConfiguredApi):
     def get_stats_for_channel_and_service(self, channel_id: str, service_id: str) -> ChannelStats:
         resp = self.get(f"{self._channels_url(service_id)}/{channel_id}/statistics")
         return ChannelStats.from_api(resp)
+
+    def peek_messages_for_subscription_and_channel_and_service(
+        self, subscription: str, channel_id: str, service_id: str
+    ) -> Dict:
+        return self.get(f"{self._channels_url(service_id)}/{channel_id}/peek/{subscription}")


### PR DESCRIPTION
## Why?
* [CONTXT-4543](https://ndustrialio.atlassian.net/browse/CONTXT-4543): Lineage wants a way to look at messages without affecting consumers

## What changed?
- [x] Added a function to make a GET request to the peek route


[CONTXT-4543]: https://ndustrialio.atlassian.net/browse/CONTXT-4543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ