### PR TITLE
chore: add newer org ID to slug mappings

### DIFF
--- a/contxt/utils/orgs.py
+++ b/contxt/utils/orgs.py
@@ -3,6 +3,10 @@ org_id_slugs = {
     "02efa741-a96f-4124-a463-ae13a704b8fc": "lineage",
     "2fe29680-fc3d-4888-9e9b-44be1e59c22c": "sfnt",
     "5209751f-ea46-4b3e-a5dd-b8d03311b791": "ndustrial",
+    "65be9a9d-5cc1-4318-8762-da74e454ea51": "vcv",
+    "bc071c66-d030-44c7-9c2a-cfe3161cdf3e": "lsc-communications",
+    "5a4bbead-7208-499e-a853-9cb174a71c63": "uscold",
+    "513b06ea-0169-4436-b3b2-77318bd77e94": "wlgore",
 }
 
 


### PR DESCRIPTION
## Why?
* [SUP-4015](https://ndustrialio.atlassian.net/browse/SUP-4015): Failure provisioning LSC

## What changed?
- [x] Added recent org IDs to slug mapping


[SUP-4015]: https://ndustrialio.atlassian.net/browse/SUP-4015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ