### PR TITLE
Remove ability to create new contxt-managed services from the CLI

### DIFF
--- a/contxt/cli/commands/services.py
+++ b/contxt/cli/commands/services.py
@@ -33,7 +33,7 @@ def get(clients: Clients, id: str, fields: List[str], sort: str) -> None:
 @click.option("--type", type=click.Choice(["API", "Application", "Worker"]), prompt=True)
 @click.option(
     "--deployment-strategy",
-    type=click.Choice(["self-managed", "contxt-managed", "unmanaged"]),
+    type=click.Choice(["self-managed", "unmanaged"]),
     prompt=True,
 )
 @click.pass_obj


### PR DESCRIPTION
## Why?
* [JIRA](https://ndustrialio.atlassian.net/browse/SUP-5223): Remove contxt-managed service creation

## What changed?
- Remove `contxt-managed` as an option.
