### PR TITLE
chore: ignore IDEA editor local dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ dmypy.json
 
 # IDE
 .vscode/
+.idea
+


### PR DESCRIPTION
## Why?
* ignore the `.idea` development directory made by PyCharm
