### PR TITLE
feat: add Python 3.12 to test matrix [CONTXT-9166]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - run: pipx install poetry


### PR DESCRIPTION
## Why?
* [CONTXT-9166](https://ndustrialio.atlassian.net/browse/CONTXT-9166)

## What changed?
- [x] Added Py 3.12 to the test matrix list

[CONTXT-9166]: https://ndustrialio.atlassian.net/browse/CONTXT-9166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ