### PR TITLE
switch to importlib for pulling distribution version info

### DIFF
--- a/contxt/__init__.py
+++ b/contxt/__init__.py
@@ -1,6 +1,6 @@
 try:
-    from pkg_resources import get_distribution  # implicit dependency on setuptools
+    from importlib.metadata import version
 
-    __version__ = get_distribution("contxt-sdk").version
+    __version__ = version("contxt-sdk")
 except Exception:
     __version__ = "unknown"


### PR DESCRIPTION
## Why?
* [JIRA](https://ndustrialio.atlassian.net/browse/CONTXT-11468): contxt-sdk-python package update
## What changed?
- [x] Update method of pulling distribution version as pkg_resources is being deprecated
