### PR TITLE
feat(dependabot-vulnerability-scan): Create Jira issues automatically

### DIFF
--- a/.github/workflows/dependabot-alerts-to-jira.yaml
+++ b/.github/workflows/dependabot-alerts-to-jira.yaml
@@ -1,0 +1,29 @@
+name: Dependabot Alerts → Jira (scheduled)
+
+on:
+  schedule:
+- cron: '23 9 * * 1-5'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  security-events: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependabot alerts → Jira (bulk)
+        uses: ndustrialio/actions/vulnerability-scan/dependabot@vulns-to-jira
+        with:
+          github-token: ${{ secrets.NIO_BOT_TOKEN }}
+          bulk-parallel: "12"        # tweak as you like
+          jira-base-url:  ${{ secrets.JIRA_BASE_URL }}
+          jira-email:     ${{ secrets.JIRA_EMAIL }}
+          jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
+          jira-team-name: "CSI"
+          jira-assignee-account-id: "5ff33f76f7ea2a01079ef10b"


### PR DESCRIPTION
## Why?
- [CONTXT-12249 -- Automate Jira ticket creation for Github Dependabot issues](https://ndustrialio.atlassian.net/browse/CONTXT-12249)
- Create Jira issues automatically from from dependabot security alerts

## What changed?
- Added Workflow file to dispatch github action that checks dependabot for security alerts and then automatically creates the Jira issues for them
