### PR TITLE
Fix version numbering

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
           git-user-name: "GitHub Actions"
           git-user-email: "action@github.com"
           version-file: pyproject.toml
-          version-path: tool.poetry.version
+          version-path: project.version
           preset: conventionalcommits
           output-file: false
       - name: Set new commit hash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,6 @@ dependencies = [
   Repository = "https://github.com/ndustrialio/contxt-sdk-python"
 
 [tool.poetry]
-version = "0.1.0"
-
   [[tool.poetry.packages]]
   include = "contxt"
 


### PR DESCRIPTION
Attempt to fix versioning CI bug introduced when porting from [tool.poetry] format to PEP 621 [project] format.

## Why?
* I apparently broke the verionsing without realizeing it when resolving VULNs

## What changed?
- Clean up workflow and pyproject.
